### PR TITLE
Mention that contentTypes setting is in frontmatter.json

### DIFF
--- a/content/docs/content-creation/index.md
+++ b/content/docs/content-creation/index.md
@@ -30,7 +30,7 @@ When using content types, the CMS will create the new content based on the follo
 
 ## How it works
 
-Behind the scenes, Front Matter uses the `frontMatter.taxonomy.contentTypes` setting to understand which type of content you'll use for your website.
+Behind the scenes, Front Matter uses the `frontMatter.taxonomy.contentTypes` setting (in the `frontmatter.json`) to understand which type of content you'll use for your website.
 
 Our default content type consists of the following fields:
 


### PR DESCRIPTION
If someone lands onto this page without context, this makes it easier to understand which files to modify. Easier for a beginner too. I am aware that this is explained in the subsection "Content types", but clarity could be added at this level too.