### PR TITLE
(MAINT) Document the diagnostic logging command

### DIFF
--- a/content/docs/commands.md
+++ b/content/docs/commands.md
@@ -36,6 +36,12 @@ Opens the dashboard with your Markdown pages overview. If you did not yet initia
 
 ID: `frontMatter.dashboard`
 
+### Diagnostic logging
+
+Opens a virtual Markdown document with detailed information about your Front Matter configuration.
+
+ID: `frontMatter.diagnostics`
+
 ### Insert image into your content
 
 Allows you to quickly insert an image reference in the Markdown file.

--- a/content/docs/settings.md
+++ b/content/docs/settings.md
@@ -70,6 +70,10 @@ Contents of the `blog.json` file:
 }
 ```
 
+### Reviewing composed settings
+
+You can inspect your composed settings with the [diagnostic logging](commands.md#diagnostic-logging) command, which shows you the [Complete `frontmatter.json` config](troubleshooting.md#inspecting-configuration-behavior) in a virtual Markdown document. Use that output to verify that your split configuration settings are applied the way you expect.
+
 ## Available settings
 
 ### frontMatter.content.autoUpdateDate

--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -27,6 +27,18 @@ The extension logs information, warnings, and errors into the Visual Studio Code
 
 ![Troubleshooting - Show the output of what the extension has been performing](/releases/v5.8.0/troubleshooting-output.png)
 
+## Inspecting configuration behavior
+
+With the [diagnostic logging](commands.md#diagnostic-logging) command, you can see your current configuration and related information in a virtual Markdown document.
+
+The document has several sections:
+
+- **Folders** lists the entries defined in `frontMatter.content.pageFolders` by their title and the full path to each folder.
+- **Workspace folder** notes the full path to your project's workspace.
+- **Total files** notes the total file count for your workspace.
+- **Folders to search files** lists the count for discovered files by type in your content folders and includes the search glob used.
+- **Complete frontmatter.json config** shows the current configuration JSON. If you [split your configuration settings](settings.md#splitting-your-settings-in-multiple-files), it shows the fully composed configuration.
+
 ## Feature migrations
 
 Sometimes it happens features get renamed or removed, under this section we will show you how to migrate your configuration to the new version.


### PR DESCRIPTION
Prior to this change, the diagnostic logging command was included in the screenshot for extension commands but not documented.

This change:

- Adds documentation for the command itself.
- Updates the troubleshooting section to clarify how it can be used and what the diagnostic logging shows.
- Adds a note to the section on splitting settings to let users know how they can review the composed settings for their project.