### PR TITLE
(GH-11) Add, configure, and enforce markdownlint rules

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,33 @@
+# Rule definitions live in .markdownlint.yaml
+
+# Include a custom rule package
+# customRules:
+#   - markdownlint-rule-titlecase
+
+# Fix any fixable errors
+fix: true
+
+# Define a custom front matter pattern
+# frontMatter: (^---\s*$[^]*?^---\s*$)(\r\n|\r|\n|$)
+
+# Define glob expressions to use (only valid at root)
+# globs:
+#   - "!*bout.md"
+
+# Define glob expressions to ignore
+ignores:
+  - "node_modules"
+
+# Use a plugin to recognize math
+# markdownItPlugins:
+#   - - "@iktakahiro/markdown-it-katex"
+
+# Disable inline config comments
+noInlineConfig: false
+
+# Disable progress on stdout (only valid at root)
+noProgress: true
+
+# Use a specific formatter (only valid at root)
+outputFormatters:
+  - [markdownlint-cli2-formatter-default]

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,92 @@
+# Be explicit about all rules. Hover on the rule in the editor to see it, or
+# review: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+MD001: true
+# MD002: Deprecated
+MD003:
+  style: atx
+MD004:
+  style: dash
+MD005: true
+# MD006: Deprecated
+MD007:
+  indent: 2
+  start_indented: false
+  start_indent: 2
+MD009:
+  br_spaces: 0
+  list_item_empty_lines: false
+  strict: true
+MD010:
+  code_blocks: true
+  spaces_per_tab: 2
+MD011: true
+MD012:
+  maximum: 1
+MD013:
+  line_length: 100
+  heading_line_length: 80
+  code_block_line_length: 80
+  code_blocks: true
+  tables: false
+  headings: true
+  headers: true
+  strict: false
+  stern: false
+MD014: true
+MD018: true
+MD019: true
+# MD020: Ignore, not using Closed-Atx Style Headings
+# MD021: Ignore, not using Closed-Atx Style Headings
+MD022:
+  lines_above: 1
+  lines_below: 1
+MD023: true
+MD024:
+  allow_different_nesting: true
+  siblings_only: false
+MD025:
+  level: 1
+  front_matter_title: ""
+MD026:
+  punctuation: .,;:!。，；：！
+MD027: true
+MD028: true
+MD029:
+  style: one
+MD030:
+  ul_single: 1
+  ol_single: 1
+  ul_multi: 1
+  ol_multi: 1
+MD031:
+  list_items: true
+MD032: true
+MD033: true
+MD034: true
+MD035:
+  style: ---
+MD036:
+  punctuation: .,;:!?。，；：！？
+MD037: true
+MD038: true
+MD039: true
+MD040: true
+MD041:
+  level: 1
+  front_matter_title: ""
+MD042: true
+# MD043: No required heading structure for most files.
+# MD044: Use Vale for capitalization, not MarkdownLint.
+MD045: true
+MD046:
+  style: fenced
+MD047: true
+MD048:
+  style: backtick
+MD049:
+  style: underscore
+MD050:
+  style: asterisk
+MD051: true
+MD052: true
+MD053: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "davidanson.vscode-markdownlint",
+    "marvhen.reflow-markdown"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "frontMatter.preview.host": "http://localhost:3000"
+  "frontMatter.preview.host": "http://localhost:3000",
+  "reflowMarkdown.preferredLineLength": 100,
+  "editor.rulers": [76, 80, 96, 100]
 }

--- a/README.md
+++ b/README.md
@@ -2,19 +2,22 @@
 
 This is the Front Matter its documentation respository.
 
-![](./public/releases/v4_0_0/banner-v2.png)
+![Banner view of Front Matter, showing the extension with the a heading that reads "Headless CMD running in VS Code"](./public/releases/v4_0_0/banner-v2.png)
 
 ## Main documentation
 
-The documentation of the main Front Matter version can be found at [frontmatter.codes](https://frontmatter.codes).
+The documentation of the main Front Matter version can be found at
+[frontmatter.codes](https://frontmatter.codes).
 
 ## BETA docs
 
-The documentation of the BETA Front Matter version can be found at [beta.frontmatter.codes](https://beta.frontmatter.codes).
+The documentation of the BETA Front Matter version can be found at
+[beta.frontmatter.codes](https://beta.frontmatter.codes).
 
 ## Issues/Feedback
 
-Please add issues or feedback of the Front Matter extension in the following repository: [Front Matter repository](https://github.com/estruyf/vscode-front-matter).
+Please add issues or feedback of the Front Matter extension in the following repository:
+[Front Matter repository](https://github.com/estruyf/vscode-front-matter).
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,27 @@
 
 This is the Front Matter its documentation respository.
 
-![Banner view of Front Matter, showing the extension with the a heading that reads "Headless CMD running in VS Code"](./public/releases/v4_0_0/banner-v2.png)
+![Banner view of Front Matter, showing the extension with the a heading that reads "Headless CMD running in VS Code"][01]
 
 ## Main documentation
 
-The documentation of the main Front Matter version can be found at
-[frontmatter.codes](https://frontmatter.codes).
+The documentation of the main Front Matter version can be found at [frontmatter.codes][02].
 
 ## BETA docs
 
-The documentation of the BETA Front Matter version can be found at
-[beta.frontmatter.codes](https://beta.frontmatter.codes).
+The documentation of the BETA Front Matter version can be found at [beta.frontmatter.codes][03].
 
 ## Issues/Feedback
 
 Please add issues or feedback of the Front Matter extension in the following repository:
-[Front Matter repository](https://github.com/estruyf/vscode-front-matter).
+[Front Matter repository][04].
 
 ## Contributions
 
 Contributions to the documentation are always welcome!
+
+<!-- Link References -->
+[01]: ./public/releases/v4_0_0/banner-v2.png
+[02]: https://frontmatter.codes
+[03]: https://beta.frontmatter.codes
+[04]: https://github.com/estruyf/vscode-front-matter

--- a/content/docs/commands.md
+++ b/content/docs/commands.md
@@ -14,7 +14,7 @@ weight: 900
 Front Matter actions are also available as commands. In this section of the documentation all
 commands will be explained.
 
-![Commands](/assets/commands-v6.1.0.png)
+![Commands][01]
 
 ## Using commands
 
@@ -172,3 +172,6 @@ ID: `frontMatter.promoteSettings`
 This command has been removed, as it became obsolete since the introduction of Content Types.
 
 ID: `frontMatter.setDate`
+
+<!-- Link References -->
+[01]: /assets/commands-v6.1.0.png

--- a/content/docs/commands.md
+++ b/content/docs/commands.md
@@ -11,7 +11,8 @@ weight: 900
 
 ## Overview
 
-Front Matter actions are also available as commands. In this section of the documentation all commands will be explained.
+Front Matter actions are also available as commands. In this section of the documentation all
+commands will be explained.
 
 ![Commands](/assets/commands-v6.1.0.png)
 
@@ -26,13 +27,15 @@ Front Matter actions are also available as commands. In this section of the docu
 
 ### Initialize project
 
-This command will initialize the project with a template folder and an article template. It makes it easier to get you started with the extension and creating your content.
+This command will initialize the project with a template folder and an article template. It makes it
+easier to get you started with the extension and creating your content.
 
 ID: `frontMatter.init`
 
 ### Open dashboard
 
-Opens the dashboard with your Markdown pages overview. If you did not yet initialize your project, the welcome screen will be shown.
+Opens the dashboard with your Markdown pages overview. If you did not yet initialize your project,
+the welcome screen will be shown.
 
 ID: `frontMatter.dashboard`
 
@@ -68,13 +71,15 @@ ID: `frontMatter.createTag`
 
 ### Insert categories
 
-Inserts a selected categories into the front matter of your article/post/... - When using this command, the Front Matter panel opens and focuses on the specified type.
+Inserts a selected categories into the front matter of your article/post/... - When using this
+command, the Front Matter panel opens and focuses on the specified type.
 
 ID: `frontMatter.insertCategories`
 
 ### Insert tags
 
-Inserts a selected tags into the front matter of your article/post/... - When using this command, the Front Matter panel opens and focuses on the specified type.
+Inserts a selected tags into the front matter of your article/post/... - When using this command,
+the Front Matter panel opens and focuses on the specified type.
 
 ID: `frontMatter.insertTags`
 
@@ -86,29 +91,37 @@ ID: `frontMatter.exportTaxonomy`
 
 ### Remap or remove tag/category in all articles
 
-This command helps you quickly update/remap or delete a tag or category in your markdown files. The extension will ask you to select the taxonomy type (tag or category), the old taxonomy value, and the new one (leave the input field blank to remove the tag/category).
+This command helps you quickly update/remap or delete a tag or category in your markdown files. The
+extension will ask you to select the taxonomy type (tag or category), the old taxonomy value, and
+the new one (leave the input field blank to remove the tag/category).
 
-> **Info**: Once the remapping/deleting process completes, your VS Code settings update with all new taxonomy tags/categories.
+> **Info**: Once the remapping/deleting process completes, your VS Code settings update with all new
+> taxonomy tags/categories.
 
 ID: `frontMatter.remap`
 
 ### Create a template from current file
 
-This command allows you to create a new template from the current open Markdown file. It will ask you for the name of the template and if you want to keep the current file its content in the template.
+This command allows you to create a new template from the current open Markdown file. It will ask
+you for the name of the template and if you want to keep the current file its content in the
+template.
 
 ID: `frontMatter.createTemplate`
 
 ### Create new content from defined content type or template
 
-With this command, you can easily create content in your project from the defined content types or templates.
+With this command, you can easily create content in your project from the defined content types or
+templates.
 
-> **Info**: The command will use the `frontMatter.templates.prefix` setting in order to add a prefix (default: `yyyy-MM-dd`) on the filename.
+> **Info**: The command will use the `frontMatter.templates.prefix` setting in order to add a prefix
+> (default: `yyyy-MM-dd`) on the filename.
 
 ID: `frontMatter.createContent`
 
 ### Generate slug based on content title
 
-This command generates a clean slug for your content. It removes known stop words, punctuations, and special characters.
+This command generates a clean slug for your content. It removes known stop words, punctuations, and
+special characters.
 
 Example:
 
@@ -119,13 +132,17 @@ slug: sample-page-title
 ---
 ```
 
-You can also specify a prefix and suffix, which can be added to the slug if you want. Use the following settings to do this: `frontMatter.taxonomy.slugPrefix` and `frontMatter.taxonomy.slugSuffix`. 
+You can also specify a prefix and suffix, which can be added to the slug if you want. Use the
+following settings to do this: `frontMatter.taxonomy.slugPrefix` and
+`frontMatter.taxonomy.slugSuffix`.
 
-By default, both prefix and suffix settings are not provided, which mean it would not add anything extra to the slug. 
+By default, both prefix and suffix settings are not provided, which mean it would not add anything
+extra to the slug.
 
-Another setting is to allow you to sync the filename with the generated slug. The setting you need to turn on enable for this is `frontMatter.taxonomy.alignFilename`.
+Another setting is to allow you to sync the filename with the generated slug. The setting you need
+to turn on enable for this is `frontMatter.taxonomy.alignFilename`.
 
-> **Info**: At the moment, the extension only supports English stopwords. 
+> **Info**: At the moment, the extension only supports English stopwords.
 
 ID: `frontMatter.generateSlug`
 
@@ -143,7 +160,8 @@ ID: `frontMatter.preview`
 
 ### Promote settings from local to team level
 
-This command allows you to promote all local settings from within your `.vscode/settings.json` file to be promoted to the projects team configuration `frontmatter.json` file.
+This command allows you to promote all local settings from within your `.vscode/settings.json` file
+to be promoted to the projects team configuration `frontmatter.json` file.
 
 ID: `frontMatter.promoteSettings`
 

--- a/content/docs/content-creation/content-type.md
+++ b/content/docs/content-creation/content-type.md
@@ -11,7 +11,9 @@ weight: 200.1
 
 ## Changing the default content type
 
-If you want to change the default content type, open your `frontmatter.json` and write an entry for the `frontMatter.taxonomy.contentTypes` setting. Visual Studio Code will automatically autocomplete it with the default content type fields.
+If you want to change the default content type, open your `frontmatter.json` and write an entry for
+the `frontMatter.taxonomy.contentTypes` setting. Visual Studio Code will automatically autocomplete
+it with the default content type fields.
 
 If in some case it wouldn't do this, here is the default content type structure:
 
@@ -114,23 +116,29 @@ The metadata section on the editor panel will render the following fields:
 
 For the content type you can configure the following properties:
 
-| Property | Type | Description | Default value |
-| --- | --- | --- | --- |
-| `name` | `string` | Name of the content type | `""`  |
-| `fields` | `array` | Check the [supported field types](/docs/content-creation/fields#supported-field-types) | `[]` |
-| `fileType` | Enum: `md, mdx, markdown, <your choice>` | File type of for the content type you define. The type will be used to create the file when creating content. | `md` |
-| `pageBundle` | `boolean` | If set to `true`, the content will be created as a page bundle (folder). | `false` |
-| `previewPath` | `string` | Defines a custom preview path for the content type. When the preview path is not set, the value from the [frontMatter.preview.pathName](https://frontmatter.codes/docs/settings#frontmatter.preview.pathname) setting will be used. | `null` |
-| `template` | `string` | Specify a path to a template file that will be used when creating new content with the content type. | `null` |
-| `postScript` | `string` | An optional post script that can be used after new content creation. In order to use this, you will have to set the value to the ID of your [content script](/docs/custom-actions/#content-script). | `null` |
+| Property      | Type                                     | Description                                                                                                                                                                                                                         | Default value |
+| ------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `name`        | `string`                                 | Name of the content type                                                                                                                                                                                                            | `""`          |
+| `fields`      | `array`                                  | Check the [supported field types](/docs/content-creation/fields#supported-field-types)                                                                                                                                              | `[]`          |
+| `fileType`    | Enum: `md, mdx, markdown, <your choice>` | File type of for the content type you define. The type will be used to create the file when creating content.                                                                                                                       | `md`          |
+| `pageBundle`  | `boolean`                                | If set to `true`, the content will be created as a page bundle (folder).                                                                                                                                                            | `false`       |
+| `previewPath` | `string`                                 | Defines a custom preview path for the content type. When the preview path is not set, the value from the [frontMatter.preview.pathName](https://frontmatter.codes/docs/settings#frontmatter.preview.pathname) setting will be used. | `null`        |
+| `template`    | `string`                                 | Specify a path to a template file that will be used when creating new content with the content type.                                                                                                                                | `null`        |
+| `postScript`  | `string`                                 | An optional post script that can be used after new content creation. In order to use this, you will have to set the value to the ID of your [content script](/docs/custom-actions/#content-script).                                 | `null`        |
 
 ## Define your own type
 
-In most cases, you'll work with multiple types of content where each type will have its defined set of fields. If this is the case for your website, you'll need to add another content type to the `frontMatter.taxonomy.contentTypes` setting.
+In most cases, you'll work with multiple types of content where each type will have its defined set
+of fields. If this is the case for your website, you'll need to add another content type to the
+`frontMatter.taxonomy.contentTypes` setting.
 
-Instead of overriding the default content type, you can also define a new content type. It requires you to specify the `name` and `fields`.
+Instead of overriding the default content type, you can also define a new content type. It requires
+you to specify the `name` and `fields`.
 
-> **Important**: The `name` property value needs to be equal to the `type` value you set in your Markdown front matter. You best define it via a template so that it's always defined. A default template will be available when initializing Front Matter in your project in the `.frontmatter/templates` folder.
+> **Important**: The `name` property value needs to be equal to the `type` value you set in your
+> Markdown front matter. You best define it via a template so that it's always defined. A default
+> template will be available when initializing Front Matter in your project in the
+> `.frontmatter/templates` folder.
 
 Sample:
 
@@ -151,7 +159,9 @@ Sample:
 ]
 ```
 
-In the sample, `documentation` is used as the content type name. This means that in your article, you'll need to add the `type: documentation` to your front matter to let the editor panel understand which fields to show.
+In the sample, `documentation` is used as the content type name. This means that in your article,
+you'll need to add the `type: documentation` to your front matter to let the editor panel understand
+which fields to show.
 
 ```markdown
 ---
@@ -165,14 +175,17 @@ type: documentation
 ---
 ```
 
-> **Fields**: Check out the [fields](/docs/content-creation/fields) section to learn which fields are supported.
-
+> **Fields**: Check out the [fields](/docs/content-creation/fields) section to learn which fields
+> are supported.
 
 ## Using a template with the content type
 
-When creating content that requires a pre-defined structure, you can use the `template` property. The `template` property allows you to link a template file. On content creation, the contents of the template file will be used to create the new content.
+When creating content that requires a pre-defined structure, you can use the `template` property.
+The `template` property allows you to link a template file. On content creation, the contents of the
+template file will be used to create the new content.
 
-You can use the `template` property on any of your content types, even on the default content type from Front Matter.
+You can use the `template` property on any of your content types, even on the default content type
+from Front Matter.
 
 ```json
 {
@@ -188,7 +201,9 @@ You can use the `template` property on any of your content types, even on the de
 
 ## Run a script after your content is created
 
-To run a custom script after your content is created, you can use the `postScript` property. The `postScript` property allows you to link a script file by referencing its `id`. The script will be executed after the content is created which gives you access to the whole front matter object.
+To run a custom script after your content is created, you can use the `postScript` property. The
+`postScript` property allows you to link a script file by referencing its `id`. The script will be
+executed after the content is created which gives you access to the whole front matter object.
 
 ```json
 {
@@ -218,4 +233,5 @@ In your custom script setting, you need to make sure that this script is availab
 }
 ```
 
-> **Info**: More information about custom scripts can be found in the [custom actions](/docs/custom-actions) section.
+> **Info**: More information about custom scripts can be found in the
+> [custom actions](/docs/custom-actions) section.

--- a/content/docs/content-creation/content-type.md
+++ b/content/docs/content-creation/content-type.md
@@ -110,21 +110,21 @@ Adapt the fields to your needs. For our documentation it looks as follows:
 
 The metadata section on the editor panel will render the following fields:
 
-![Adapted default content type fields](/assets/adapted-default-ct.png)
+![Adapted default content type fields][01]
 
 ### Content type properties
 
 For the content type you can configure the following properties:
 
-| Property      | Type                                     | Description                                                                                                                                                                                                                         | Default value |
-| ------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `name`        | `string`                                 | Name of the content type                                                                                                                                                                                                            | `""`          |
-| `fields`      | `array`                                  | Check the [supported field types](/docs/content-creation/fields#supported-field-types)                                                                                                                                              | `[]`          |
-| `fileType`    | Enum: `md, mdx, markdown, <your choice>` | File type of for the content type you define. The type will be used to create the file when creating content.                                                                                                                       | `md`          |
-| `pageBundle`  | `boolean`                                | If set to `true`, the content will be created as a page bundle (folder).                                                                                                                                                            | `false`       |
-| `previewPath` | `string`                                 | Defines a custom preview path for the content type. When the preview path is not set, the value from the [frontMatter.preview.pathName](https://frontmatter.codes/docs/settings#frontmatter.preview.pathname) setting will be used. | `null`        |
-| `template`    | `string`                                 | Specify a path to a template file that will be used when creating new content with the content type.                                                                                                                                | `null`        |
-| `postScript`  | `string`                                 | An optional post script that can be used after new content creation. In order to use this, you will have to set the value to the ID of your [content script](/docs/custom-actions/#content-script).                                 | `null`        |
+| Property      | Type                                     | Description                                                                                                                                                       | Default value |
+| ------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `name`        | `string`                                 | Name of the content type                                                                                                                                          | `""`          |
+| `fields`      | `array`                                  | Check the [supported field types][02]                                                                                                                             | `[]`          |
+| `fileType`    | Enum: `md, mdx, markdown, <your choice>` | File type of for the content type you define. The type will be used to create the file when creating content.                                                     | `md`          |
+| `pageBundle`  | `boolean`                                | If set to `true`, the content will be created as a page bundle (folder).                                                                                          | `false`       |
+| `previewPath` | `string`                                 | Defines a custom preview path for the content type. When the preview path is not set, the value from the [frontMatter.preview.pathName][03] setting will be used. | `null`        |
+| `template`    | `string`                                 | Specify a path to a template file that will be used when creating new content with the content type.                                                              | `null`        |
+| `postScript`  | `string`                                 | An optional post script that can be used after new content creation. In order to use this, you will have to set the value to the ID of your [content script][04]. | `null`        |
 
 ## Define your own type
 
@@ -175,8 +175,7 @@ type: documentation
 ---
 ```
 
-> **Fields**: Check out the [fields](/docs/content-creation/fields) section to learn which fields
-> are supported.
+> **Fields**: Check out the [fields][05] section to learn which fields are supported.
 
 ## Using a template with the content type
 
@@ -234,4 +233,12 @@ In your custom script setting, you need to make sure that this script is availab
 ```
 
 > **Info**: More information about custom scripts can be found in the
-> [custom actions](/docs/custom-actions) section.
+> [custom actions][06] section.
+
+<!-- Link References -->
+[01]: /assets/adapted-default-ct.png
+[02]: /docs/content-creation/fields#supported-field-types
+[03]: https://frontmatter.codes/docs/settings#frontmatter.preview.pathname
+[04]: /docs/custom-actions/#content-script
+[05]: /docs/content-creation/fields
+[06]: /docs/custom-actions

--- a/content/docs/content-creation/fields.md
+++ b/content/docs/content-creation/fields.md
@@ -39,25 +39,27 @@ There are also the following section fields:
 
 All fields share the following field properties:
 
-| Property | Type | Description | Optional / Required |
-| ----- | ----- | ----- | ----- |
-| `name` | `string` | The name of your field, will be used to set in the front matter of your Markdown file. | **Required** |
-| `type` | `string` | The type of the field. Use one of the supported field types. | **Required** |
-| `title` | `string` | The title to show in the metadata section | *Optional* |
-| `description` | `string` | The description to show underneath the field | *Optional* |
-| `default` | `string` | Defines the default value for the field when creating the content type. You can also use placeholders like `{{title}}`, `{{slug}}` or `{{now}}`. Check for more information under [placeholders](/docs/content-creation/placeholders). | *Optional* |
-| `required` | `boolean` | Defines if the field is required or not. If set to true, and the user does not define a value, a notification will appear. You can disable this notification with the [frontMatter.global.disabledNotifications](/docs/settings#frontmatter.global.disablednotifications) setting. | *Optional* |
-| `hidden` | `boolean` | Specifies if you want to hide the field from the metadata section, but still have it available in Front Matter. | *Optional* |
-
+| Property      | Type      | Description                                                                                                                                                                                                                                                                        | Optional / Required |
+| ------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `name`        | `string`  | The name of your field, will be used to set in the front matter of your Markdown file.                                                                                                                                                                                             | **Required**        |
+| `type`        | `string`  | The type of the field. Use one of the supported field types.                                                                                                                                                                                                                       | **Required**        |
+| `title`       | `string`  | The title to show in the metadata section                                                                                                                                                                                                                                          | _Optional_          |
+| `description` | `string`  | The description to show underneath the field                                                                                                                                                                                                                                       | _Optional_          |
+| `default`     | `string`  | Defines the default value for the field when creating the content type. You can also use placeholders like `{{title}}`, `{{slug}}` or `{{now}}`. Check for more information under [placeholders](/docs/content-creation/placeholders).                                             | _Optional_          |
+| `required`    | `boolean` | Defines if the field is required or not. If set to true, and the user does not define a value, a notification will appear. You can disable this notification with the [frontMatter.global.disabledNotifications](/docs/settings#frontmatter.global.disablednotifications) setting. | _Optional_          |
+| `hidden`      | `boolean` | Specifies if you want to hide the field from the metadata section, but still have it available in Front Matter.                                                                                                                                                                    | _Optional_          |
 
 ## String
 
-The `string` field type is used to store a single-line or multiline of text. For instance, you can use if for the title, description, or any other text field.
+The `string` field type is used to store a single-line or multiline of text. For instance, you can
+use if for the title, description, or any other text field.
 
 ### Properties
 
-- `single (boolean)`: When you picked the `string` field type, you can specify if it is a single line. By default it will render as a multiline field (optional).
-- `wysiwyg (boolean)`: When you set this value to `true`, the field will be rendered as a WYSIWYG editor. The output of the WYSIWYG editor will be HTML.
+- `single (boolean)`: When you picked the `string` field type, you can specify if it is a single
+  line. By default it will render as a multiline field (optional).
+- `wysiwyg (boolean)`: When you set this value to `true`, the field will be rendered as a WYSIWYG
+  editor. The output of the WYSIWYG editor will be HTML.
 
 ![WYSIWYG controls](/releases/v7.2.0/wysiwyg-controls.png)
 
@@ -80,11 +82,10 @@ title: "My title"
 ---
 ```
 
-
-
 ## Number
 
-The `number` field allows you to insert integer values, like for instance setting the weight of your content.
+The `number` field allows you to insert integer values, like for instance setting the weight of your
+content.
 
 ### Usage
 
@@ -104,18 +105,21 @@ weight: 1
 ---
 ```
 
-
-
 ## Datetime
 
-The `datetime` field allows you to add date fields. You can use it for publish, modified, and any other types of dates for you content.
+The `datetime` field allows you to add date fields. You can use it for publish, modified, and any
+other types of dates for you content.
 
 ### Properties
 
-- `isPublishDate`: Specifies if the field is a publish date. When set to `true`, the field will be used to set the publish date for the content (this will be reflected on the content dashboard). 
-- `isModifiedDate`: Specifies if the field is a modified date. When using the `frontMatter.content.autoUpdateDate` setting to automatically update the modified date of the article, this field will be used.
+- `isPublishDate`: Specifies if the field is a publish date. When set to `true`, the field will be
+  used to set the publish date for the content (this will be reflected on the content dashboard).
+- `isModifiedDate`: Specifies if the field is a modified date. When using the
+  `frontMatter.content.autoUpdateDate` setting to automatically update the modified date of the
+  article, this field will be used.
 
-> The format of your date can be defined in the `frontMatter.taxonomy.dateFormat` setting. Check [date-fns formating](https://date-fns.org/v2.0.1/docs/format) for more information.
+> The format of your date can be defined in the `frontMatter.taxonomy.dateFormat` setting. Check
+> [date-fns formating](https://date-fns.org/v2.0.1/docs/format) for more information.
 
 ### Usage
 
@@ -143,10 +147,10 @@ lastmod: 2022-03-14T08:42:22.364Z
 ---
 ```
 
-
 ## Boolean
 
-The `boolean` field can be used to set a value of `true` or `false` into your markdown. It will be rendered as a toggle.
+The `boolean` field can be used to set a value of `true` or `false` into your markdown. It will be
+rendered as a toggle.
 
 ### Usage
 
@@ -166,16 +170,16 @@ isPublished: true
 ---
 ```
 
-
-
 ## Choice
 
 The `choice` field allows you to define a set of options.
 
 ### Properties
 
-- `choices (string[] | { id: string; title: string; })`: When you picked the `choice` field type, you need to return an array of choices.
-- `multiple (boolean)`: Define if you want to allow multiple choice selection. By default this is `false`.
+- `choices (string[] | { id: string; title: string; })`: When you picked the `choice` field type,
+  you need to return an array of choices.
+- `multiple (boolean)`: Define if you want to allow multiple choice selection. By default this is
+  `false`.
 
 ### Usage
 
@@ -228,8 +232,6 @@ choice: "1"
 ---
 ```
 
-
-
 ## List
 
 The `list` field allows you to add multiple text values.
@@ -258,17 +260,20 @@ alias:
 ---
 ```
 
-
-
 ## Draft
 
-The `draft` field defines the state of your content. This is used for the content dashboard as well. By default, the draft field is a boolean. If you want to use your own status values, you can configure it via the [frontmatter.content.draftfield](/docs/settings#frontmatter.content.draftfield) setting.
+The `draft` field defines the state of your content. This is used for the content dashboard as well.
+By default, the draft field is a boolean. If you want to use your own status values, you can
+configure it via the
+[frontmatter.content.draftfield](/docs/settings#frontmatter.content.draftfield) setting.
 
 When using a custom draft status, the content dashboard will make use of it as well:
 
 ![Draft filters](/releases/v5.3.0/draft-status.png)
 
-> **Important**: If you use Jekyll, you do not have to use the draft field, as Front Matter supports the `_drafts`, `_posts` folders and collections from Jekyll. If you use Jekyll, make sure to set the `frontMatter.framework.id` setting to `jekyll`.
+> **Important**: If you use Jekyll, you do not have to use the draft field, as Front Matter supports
+> the `_drafts`, `_posts` folders and collections from Jekyll. If you use Jekyll, make sure to set
+> the `frontMatter.framework.id` setting to `jekyll`.
 
 ### Example 1
 
@@ -296,7 +301,8 @@ draft: true
 
 #### Usage
 
-In case you want to use a published field, instead of a draft field. You can invert the logic by setting the `invert` property to `true`:
+In case you want to use a published field, instead of a draft field. You can invert the logic by
+setting the `invert` property to `true`:
 
 ```json
 "frontMatter.content.draftField": {
@@ -330,7 +336,8 @@ published: false
 
 #### Usage
 
-If you want to use your own status values, you can define it by specifying these in the `frontMatter.content.draftField` setting:
+If you want to use your own status values, you can define it by specifying these in the
+`frontMatter.content.draftField` setting:
 
 ```json
 "frontMatter.content.draftField": {
@@ -360,16 +367,17 @@ draft: "in progress"
 ---
 ```
 
-
-
 ## Image
 
 The `image` field can be used to reference single or multiple images to your content.
 
 ### Properties
 
-- `isPreviewImage (boolean)`: Allows you to specify a custom preview image for your article. When you set this to `true` for an image field in your content type, it will be adopted in the dashboard.
-- `multiple (boolean)`: Define if you want to allow to select multiple images. By default this is `false`.
+- `isPreviewImage (boolean)`: Allows you to specify a custom preview image for your article. When
+  you set this to `true` for an image field in your content type, it will be adopted in the
+  dashboard.
+- `multiple (boolean)`: Define if you want to allow to select multiple images. By default this is
+  `false`.
 
 > **Important**: You can only set this on one image field per content type.
 
@@ -392,17 +400,16 @@ preview: /social/400285cf-4928-4c07-8ca5-158f249a3bc1.png
 ---
 ```
 
-
-
-
 ## File
 
 The `file` field can be used to reference single or multiple files to your content.
 
 ### Properties
 
-- `multiple (boolean)`: Define if you want to allow to select multiple files. By default this is `false`.
-- `fileExtensions (string array)`: Define the file extensions that are allowed to be selected. By default this is an empty array `[]`.
+- `multiple (boolean)`: Define if you want to allow to select multiple files. By default this is
+  `false`.
+- `fileExtensions (string array)`: Define the file extensions that are allowed to be selected. By
+  default this is an empty array `[]`.
 
 ### Usage
 
@@ -426,27 +433,27 @@ attachments:
 ---
 ```
 
-
-
-
 ## Tags
 
-The `tags` field allows you to create or use tags from your `frontMatter.taxonomy.tags` setting (by default, none existing). When adding a tag which does not yet exist, you will have the option to create it. 
+The `tags` field allows you to create or use tags from your `frontMatter.taxonomy.tags` setting (by
+default, none existing). When adding a tag which does not yet exist, you will have the option to
+create it.
 
 ![Add a new tag](/assets/tag-creation.png)
 
 When the tag is created, you will be able to re-use it for other content.
 
-> **Info**: You can add multiple tags at once by entering them as **comma-separated** values and pressing the **ENTER** key.
+> **Info**: You can add multiple tags at once by entering them as **comma-separated** values and
+> pressing the **ENTER** key.
 
 ### Properties
 
-- `taxonomyLimit`: Defines the maximum number of items that can be selected. By default set to `0` which allows unlimited items to be selected.
+- `taxonomyLimit`: Defines the maximum number of items that can be selected. By default set to `0`
+  which allows unlimited items to be selected.
 
 > **Info**: When a limit is defined, this will get reflected in the UI as well:
 
 ![Taxonomy limit](/assets/tags-limit.png)
-
 
 ### Usage
 
@@ -470,15 +477,16 @@ tags:
 ---
 ```
 
-
-
 ## Categories
 
-The `categories` field is similar to the [tags](/docs/content-creation/fields#tags) field. The difference is that it uses the `frontMatter.taxonomy.categories` setting (by default, none existing).
+The `categories` field is similar to the [tags](/docs/content-creation/fields#tags) field. The
+difference is that it uses the `frontMatter.taxonomy.categories` setting (by default, none
+existing).
 
 ### Properties
 
-- `taxonomyLimit`: Defines the maximum number of items that can be selected. By default set to `0` which allows unlimited items to be selected.
+- `taxonomyLimit`: Defines the maximum number of items that can be selected. By default set to `0`
+  which allows unlimited items to be selected.
 
 ### Usage
 
@@ -499,20 +507,22 @@ categories:
 ---
 ```
 
-
-
 ## Taxonomy
 
-The `taxonomy` is similar to the tags and categories field, but allows you to define your own taxonomy values and structure.
+The `taxonomy` is similar to the tags and categories field, but allows you to define your own
+taxonomy values and structure.
 
 ### Properties
 
-- `taxonomyLimit`: Defines the maximum number of items that can be selected. By default set to `0` which allows unlimited items to be selected.
-- `taxonomyId`: Set the id of your custom taxonomy definition defined in the `frontMatter.taxonomy.customTaxonomy` setting.
+- `taxonomyLimit`: Defines the maximum number of items that can be selected. By default set to `0`
+  which allows unlimited items to be selected.
+- `taxonomyId`: Set the id of your custom taxonomy definition defined in the
+  `frontMatter.taxonomy.customTaxonomy` setting.
 
 ### Custom taxonomy
 
-The `frontMatter.taxonomy.customTaxonomy` setting allows you to provide a list of custom taxonomy data. Each of the taxonomy data contains a `id` and an array of `options`.
+The `frontMatter.taxonomy.customTaxonomy` setting allows you to provide a list of custom taxonomy
+data. Each of the taxonomy data contains a `id` and an array of `options`.
 
 Here is an example of the custom taxonomy setting definition:
 
@@ -549,13 +559,14 @@ customTags:
 ---
 ```
 
-
-
 ## Fields
 
-The `fields` field, allows you to create multi-dimensional content type fields (sub-fields). This is useful when you want to create a complex content type. In case you want to define a list data, you will have to use the [block](/docs/content-creation/fields#block) field.
+The `fields` field, allows you to create multi-dimensional content type fields (sub-fields). This is
+useful when you want to create a complex content type. In case you want to define a list data, you
+will have to use the [block](/docs/content-creation/fields#block) field.
 
-When you specify the field type as `fields`, you need to define sub-fields within the `fields` property.
+When you specify the field type as `fields`, you need to define sub-fields within the `fields`
+property.
 
 ### Properties
 
@@ -606,7 +617,6 @@ photo:
 ---
 ```
 
-
 ## Block
 
 The `block` field type allows you to define a group of fields which can be used to create a list of data.
@@ -615,7 +625,8 @@ The `block` field type allows you to define a group of fields which can be used 
 
 ### Prerequisites
 
-To work with the `block` field type, you need to define a field group (a set of fields for your data) in the `frontMatter.taxonomy.fieldGroups` setting.
+To work with the `block` field type, you need to define a field group (a set of fields for your
+data) in the `frontMatter.taxonomy.fieldGroups` setting.
 
 ```json
 "frontMatter.taxonomy.fieldGroups": [
@@ -666,7 +677,8 @@ To work with the `block` field type, you need to define a field group (a set of 
 ]
 ```
 
-> **Important**: If you want, you can also create field groupings within the field grouping. This is useful when you want to create sub-groups of data.
+> **Important**: If you want, you can also create field groupings within the field grouping. This is
+> useful when you want to create sub-groups of data.
 
 ### Outcome
 
@@ -679,17 +691,18 @@ authors:
 ---
 ```
 
-
-
 ## Data file
 
-The `dataFile` field type allows you to use a data file to populate the field with a list of options. For instance, if you have a data file with all the authors of your site, you can use the `dataFile` field type to populate the `authors` field with the data from the authors data file.
+The `dataFile` field type allows you to use a data file to populate the field with a list of
+options. For instance, if you have a data file with all the authors of your site, you can use the
+`dataFile` field type to populate the `authors` field with the data from the authors data file.
 
 ![dataFile field](/releases/v7.3.0/datafile-field.png)
 
 ### Prerequisites
 
-To use the `dataFile` field type, you need to have a definition for a data file in place. Here is an example of the authors sample:
+To use the `dataFile` field type, you need to have a definition for a data file in place. Here is an
+example of the authors sample:
 
 ```json
 {
@@ -727,7 +740,8 @@ To use the `dataFile` field type, you need to have a definition for a data file 
 
 - `dataFileId`: Specify the ID of the data file to use for this field (required).
 - `dataFileKey`: Specify the key of the data file to use for this field (required).
-- `dataFileValue`: Specify the property name that will be used to show the value for the field (optional).
+- `dataFileValue`: Specify the property name that will be used to show the value for the field
+  (optional).
 - `multiple`: Specify if you want to select one or multiple records (optional).
 
 ### Usage
@@ -760,8 +774,6 @@ author:
 ---
 ```
 
-
-
 ## Slug
 
 The `slug` field allows you to create/update the slug of the current page.
@@ -770,8 +782,8 @@ The `slug` field allows you to create/update the slug of the current page.
 
 ### Properties
 
-- `editable`: Specify if you allow manual changes, or if the slug is generated automatically (optional - default: `true`).
-
+- `editable`: Specify if you allow manual changes, or if the slug is generated automatically
+  (optional - default: `true`).
 
 ### Usage
 
@@ -797,13 +809,13 @@ slug: version-8-0-0-release-notes
 ---
 ```
 
-> **Info**: The slug is generated based on the title of the page. More information about it can be found in the [generate slug](/docs/commands#generate-slug-based-on-content-title) command section.
-
-
+> **Info**: The slug is generated based on the title of the page. More information about it can be
+> found in the [generate slug](/docs/commands#generate-slug-based-on-content-title) command section.
 
 ## Divider
 
-The `divider` field type allows you to add a divider to your content type. This is useful when you want to group fields together.
+The `divider` field type allows you to add a divider to your content type. This is useful when you
+want to group fields together.
 
 ### Properties
 
@@ -822,11 +834,10 @@ You only need to specify the `type` property and name:
 
 ![Section divider field](/releases/v8.1.0/section-divider.png)
 
-
-
 ## Heading
 
-The `heading` field type allows you to add a heading to your content type. This is useful when you want to group fields together.
+The `heading` field type allows you to add a heading to your content type. This is useful when you
+want to group fields together.
 
 ### Usage
 

--- a/content/docs/content-creation/fields.md
+++ b/content/docs/content-creation/fields.md
@@ -39,15 +39,15 @@ There are also the following section fields:
 
 All fields share the following field properties:
 
-| Property      | Type      | Description                                                                                                                                                                                                                                                                        | Optional / Required |
-| ------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `name`        | `string`  | The name of your field, will be used to set in the front matter of your Markdown file.                                                                                                                                                                                             | **Required**        |
-| `type`        | `string`  | The type of the field. Use one of the supported field types.                                                                                                                                                                                                                       | **Required**        |
-| `title`       | `string`  | The title to show in the metadata section                                                                                                                                                                                                                                          | _Optional_          |
-| `description` | `string`  | The description to show underneath the field                                                                                                                                                                                                                                       | _Optional_          |
-| `default`     | `string`  | Defines the default value for the field when creating the content type. You can also use placeholders like `{{title}}`, `{{slug}}` or `{{now}}`. Check for more information under [placeholders](/docs/content-creation/placeholders).                                             | _Optional_          |
-| `required`    | `boolean` | Defines if the field is required or not. If set to true, and the user does not define a value, a notification will appear. You can disable this notification with the [frontMatter.global.disabledNotifications](/docs/settings#frontmatter.global.disablednotifications) setting. | _Optional_          |
-| `hidden`      | `boolean` | Specifies if you want to hide the field from the metadata section, but still have it available in Front Matter.                                                                                                                                                                    | _Optional_          |
+| Property      | Type      | Description                                                                                                                                                                                                                   | Optional / Required |
+| ------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `name`        | `string`  | The name of your field, will be used to set in the front matter of your Markdown file.                                                                                                                                        | **Required**        |
+| `type`        | `string`  | The type of the field. Use one of the supported field types.                                                                                                                                                                  | **Required**        |
+| `title`       | `string`  | The title to show in the metadata section                                                                                                                                                                                     | _Optional_          |
+| `description` | `string`  | The description to show underneath the field                                                                                                                                                                                  | _Optional_          |
+| `default`     | `string`  | Defines the default value for the field when creating the content type. You can also use placeholders like `{{title}}`, `{{slug}}` or `{{now}}`. Check for more information under [placeholders][01].                         | _Optional_          |
+| `required`    | `boolean` | Defines if the field is required or not. If set to true, and the user does not define a value, a notification will appear. You can disable this notification with the [frontMatter.global.disabledNotifications][02] setting. | _Optional_          |
+| `hidden`      | `boolean` | Specifies if you want to hide the field from the metadata section, but still have it available in Front Matter.                                                                                                               | _Optional_          |
 
 ## String
 
@@ -61,7 +61,7 @@ use if for the title, description, or any other text field.
 - `wysiwyg (boolean)`: When you set this value to `true`, the field will be rendered as a WYSIWYG
   editor. The output of the WYSIWYG editor will be HTML.
 
-![WYSIWYG controls](/releases/v7.2.0/wysiwyg-controls.png)
+![WYSIWYG controls][03]
 
 ### Usage
 
@@ -119,7 +119,7 @@ other types of dates for you content.
   article, this field will be used.
 
 > The format of your date can be defined in the `frontMatter.taxonomy.dateFormat` setting. Check
-> [date-fns formating](https://date-fns.org/v2.0.1/docs/format) for more information.
+> [date-fns formating][04] for more information.
 
 ### Usage
 
@@ -264,12 +264,11 @@ alias:
 
 The `draft` field defines the state of your content. This is used for the content dashboard as well.
 By default, the draft field is a boolean. If you want to use your own status values, you can
-configure it via the
-[frontmatter.content.draftfield](/docs/settings#frontmatter.content.draftfield) setting.
+configure it via the [frontmatter.content.draftfield][05] setting.
 
 When using a custom draft status, the content dashboard will make use of it as well:
 
-![Draft filters](/releases/v5.3.0/draft-status.png)
+![Draft filters][06]
 
 > **Important**: If you use Jekyll, you do not have to use the draft field, as Front Matter supports
 > the `_drafts`, `_posts` folders and collections from Jekyll. If you use Jekyll, make sure to set
@@ -439,7 +438,7 @@ The `tags` field allows you to create or use tags from your `frontMatter.taxonom
 default, none existing). When adding a tag which does not yet exist, you will have the option to
 create it.
 
-![Add a new tag](/assets/tag-creation.png)
+![Add a new tag][07]
 
 When the tag is created, you will be able to re-use it for other content.
 
@@ -453,7 +452,7 @@ When the tag is created, you will be able to re-use it for other content.
 
 > **Info**: When a limit is defined, this will get reflected in the UI as well:
 
-![Taxonomy limit](/assets/tags-limit.png)
+![Taxonomy limit][08]
 
 ### Usage
 
@@ -479,9 +478,8 @@ tags:
 
 ## Categories
 
-The `categories` field is similar to the [tags](/docs/content-creation/fields#tags) field. The
-difference is that it uses the `frontMatter.taxonomy.categories` setting (by default, none
-existing).
+The `categories` field is similar to the [tags][09] field. The difference is that it uses the
+`frontMatter.taxonomy.categories` setting (by default, none existing).
 
 ### Properties
 
@@ -563,7 +561,7 @@ customTags:
 
 The `fields` field, allows you to create multi-dimensional content type fields (sub-fields). This is
 useful when you want to create a complex content type. In case you want to define a list data, you
-will have to use the [block](/docs/content-creation/fields#block) field.
+will have to use the [block][10] field.
 
 When you specify the field type as `fields`, you need to define sub-fields within the `fields`
 property.
@@ -607,7 +605,7 @@ property.
 
 ### Outcome
 
-![Multi-dimensional content type fields](/releases/v6.0.0/multi-dimensional-content-type-fields.png)
+![Multi-dimensional content type fields][11]
 
 ```markdown
 ---
@@ -621,7 +619,7 @@ photo:
 
 The `block` field type allows you to define a group of fields which can be used to create a list of data.
 
-![Block field type rendering](/assets/block-field-type.png)
+![Block field type rendering][12]
 
 ### Prerequisites
 
@@ -697,7 +695,7 @@ The `dataFile` field type allows you to use a data file to populate the field wi
 options. For instance, if you have a data file with all the authors of your site, you can use the
 `dataFile` field type to populate the `authors` field with the data from the authors data file.
 
-![dataFile field](/releases/v7.3.0/datafile-field.png)
+![dataFile field][13]
 
 ### Prerequisites
 
@@ -778,7 +776,7 @@ author:
 
 The `slug` field allows you to create/update the slug of the current page.
 
-![Slug field](/releases/v8.0.0/slug-field.png)
+![Slug field][14]
 
 ### Properties
 
@@ -810,7 +808,7 @@ slug: version-8-0-0-release-notes
 ```
 
 > **Info**: The slug is generated based on the title of the page. More information about it can be
-> found in the [generate slug](/docs/commands#generate-slug-based-on-content-title) command section.
+> found in the [generate slug][15] command section.
 
 ## Divider
 
@@ -832,7 +830,7 @@ You only need to specify the `type` property and name:
 
 ### Outcome
 
-![Section divider field](/releases/v8.1.0/section-divider.png)
+![Section divider field][16]
 
 ## Heading
 
@@ -857,4 +855,23 @@ want to group fields together.
 
 ### Outcome
 
-![Section heading field](/releases/v8.1.0/section-heading.png)
+![Section heading field][17]
+
+<!-- Link References -->
+[01]: /docs/content-creation/placeholders
+[02]: /docs/settings#frontmatter.global.disablednotifications
+[03]: /releases/v7.2.0/wysiwyg-controls.png
+[04]: https://date-fns.org/v2.0.1/docs/format
+[05]: /docs/settings#frontmatter.content.draftfield
+[06]: /releases/v5.3.0/draft-status.png
+[07]: /assets/tag-creation.png
+[08]: /assets/tags-limit.png
+[09]: /docs/content-creation/fields#tags
+[10]: /docs/content-creation/fields#block
+[11]: /releases/v6.0.0/multi-dimensional-content-type-fields.png
+[12]: /assets/block-field-type.png
+[13]: /releases/v7.3.0/datafile-field.png
+[14]: /releases/v8.0.0/slug-field.png
+[15]: /docs/commands#generate-slug-based-on-content-title
+[16]: /releases/v8.1.0/section-divider.png
+[17]: /releases/v8.1.0/section-heading.png

--- a/content/docs/content-creation/index.md
+++ b/content/docs/content-creation/index.md
@@ -57,4 +57,7 @@ Our default content type consists of the following fields:
 We'll use the default one when you start writing your markdown content, and no other content type is
 defined.
 
-![Default content type fields](/assets/default-contenttype.png)
+![Default content type fields][01]
+
+<!-- Link References -->
+[01]: /assets/default-contenttype.png

--- a/content/docs/content-creation/index.md
+++ b/content/docs/content-creation/index.md
@@ -13,24 +13,33 @@ tags:
 
 ## Overview
 
-As each website is different, Front Matter allows you to create content by using content types or templates. 
+As each website is different, Front Matter allows you to create content by using content types or
+templates.
 
-When using content types or templates, Front Matter adapts the metadata fields shown in the editor panel to the corresponding fields in your content type or template.
+When using content types or templates, Front Matter adapts the metadata fields shown in the editor
+panel to the corresponding fields in your content type or template.
 
-Front Matter comes with a default content type and template definition which you can adapt to your needs or add your types next to it.
+Front Matter comes with a default content type and template definition which you can adapt to your
+needs or add your types next to it.
 
 ## Before you start
 
-Front Matter supports both `md` and `mdx` files. If you use the templating functionality, the CMS will automatically use the file extension of the template.
+Front Matter supports both `md` and `mdx` files. If you use the templating functionality, the CMS
+will automatically use the file extension of the template.
 
 When using content types, the CMS will create the new content based on the following rules:
 
-1. The extension checks if the content type has the `fileType` property defined. If set, the CMS uses the file type set in the property.
-2. If the content type has no `fileType` property defined, the CMS uses the default file type defined in the `frontMatter.content.defaultFileType` setting. By default, the CMS uses `md`. If you want to use `mdx`, you need to set the `frontMatter.content.defaultFileType` setting to `mdx`.
+1. The extension checks if the content type has the `fileType` property defined. If set, the CMS
+   uses the file type set in the property.
+1. If the content type has no `fileType` property defined, the CMS uses the default file type
+   defined in the `frontMatter.content.defaultFileType` setting. By default, the CMS uses `md`. If
+   you want to use `mdx`, you need to set the `frontMatter.content.defaultFileType` setting to
+   `mdx`.
 
 ## How it works
 
-Behind the scenes, Front Matter uses the `frontMatter.taxonomy.contentTypes` setting to understand which type of content you'll use for your website.
+Behind the scenes, Front Matter uses the `frontMatter.taxonomy.contentTypes` setting to understand
+which type of content you'll use for your website.
 
 Our default content type consists of the following fields:
 
@@ -42,8 +51,10 @@ Our default content type consists of the following fields:
 - tags: `tags`
 - categories: `categories`
 
-> **Info**: The default content type will create an individual Markdown file when creating content. If you want to use page bundles, make sure to specify this on the content type level.
+> **Info**: The default content type will create an individual Markdown file when creating content.
+> If you want to use page bundles, make sure to specify this on the content type level.
 
-We'll use the default one when you start writing your markdown content, and no other content type is defined.
+We'll use the default one when you start writing your markdown content, and no other content type is
+defined.
 
 ![Default content type fields](/assets/default-contenttype.png)

--- a/content/docs/content-creation/other.md
+++ b/content/docs/content-creation/other.md
@@ -7,15 +7,18 @@ lastmod: 2022-07-11T13:34:50.810Z
 weight: 200.4
 ---
 
+# Additional configuration
+
 ## Preview path
 
-For more information on how to use the preview path, see the [preview configuration](/docs/site-preview#configuration) section.
+For more information on how to use the preview path, see the
+[preview configuration](/docs/site-preview#configuration) section.
 
 ## Page and leaf bundles
 
 The page or leaf bundles, are a way to group your pages and resources together in a single folder.
 
-```
+```text
 content/
 ├── about
 │   ├── index.md
@@ -33,9 +36,11 @@ content/
         └── index.md
 ```
 
-In the above section you can see the `leaf-bundle` folders. These bundles consist of a `index.md` file and possibly also the resouces related to it like images.
+In the above section you can see the `leaf-bundle` folders. These bundles consist of a `index.md`
+file and possibly also the resouces related to it like images.
 
-By default, Front Matter will create individual Markdown files, but you can also create a leaf bundle. In order to do so, you need to set the `pageBundle` property in your content type to `true`.
+By default, Front Matter will create individual Markdown files, but you can also create a leaf
+bundle. In order to do so, you need to set the `pageBundle` property in your content type to `true`.
 
 Here is an example of configuring the page bundles for the `default` content type:
 
@@ -53,15 +58,17 @@ Here is an example of configuring the page bundles for the `default` content typ
 
 ## Creating a template
 
-To make sure that your type of content is already defined when creating a new Markdown file. It will be easier to set the type of content within a template.
+To make sure that your type of content is already defined when creating a new Markdown file. It will
+be easier to set the type of content within a template.
 
-You can create Markdown templates in your project's `.frontmatter/templates` folder (or defined differently).
+You can create Markdown templates in your project's `.frontmatter/templates` folder (or defined
+differently).
 
 ```markdown
 ---
-title: 
-slug: 
-description: 
+title:
+slug:
+description:
 date: 2019-08-22T15:20:28.000Z
 lastmod: 2019-08-22T15:20:28.000Z
 weight: 1
@@ -69,15 +76,20 @@ type: documentation
 ---
 ```
 
-If you already have an existing page, you can automatically create a template from it by running the `Front Matter: Create a template from the current file` command.
+If you already have an existing page, you can automatically create a template from it by running the
+`Front Matter: Create a template from the current file` command.
 
-The create template command will ask you the template's name and if you want to include the content. The front matter data is included by default.
+The create template command will ask you the template's name and if you want to include the content.
+The front matter data is included by default.
 
 ## Preserve casing of file names
 
-When you create a new page, the file name will be created based on the sanitized `title` property. During the sanitization, the `title` property will be converted to lowercase and all spaces will be replaced with dashes.
+When you create a new page, the file name will be created based on the sanitized `title` property.
+During the sanitization, the `title` property will be converted to lowercase and all spaces will be
+replaced with dashes.
 
-If you want to preserve the casing of the file name, you can set the `frontMatter.file.preserveCasing` setting to `true`.
+If you want to preserve the casing of the file name, you can set the
+`frontMatter.file.preserveCasing` setting to `true`.
 
 ```json
 {

--- a/content/docs/content-creation/placeholders.md
+++ b/content/docs/content-creation/placeholders.md
@@ -9,22 +9,26 @@ weight: 200.3
 
 # Placeholders
 
-Placeholders can be used in content type fields or templates. The placeholders allow you to automatically fill in values when creating a new content.
+Placeholders can be used in content type fields or templates. The placeholders allow you to
+automatically fill in values when creating a new content.
 
 There are known placeholders from Front Matter:
 
 - `{{title}}`: Title of the page
 - `{{slug}}`: Slug of the page
-- `{{now}}`: Current date formatted with the value defined in `frontMatter.taxonomy.dateFormat` or ISO string
+- `{{now}}`: Current date formatted with the value defined in `frontMatter.taxonomy.dateFormat` or
+  ISO string
 - `{{year}}`: Current year
 - `{{month}}`: Current month
 - `{{day}}`: Current day
 
 ## Custom placeholders
 
-You can define you own placeholders within the `frontMatter.content.placeholders` setting. There are two types of placeholders you can create:
+You can define you own placeholders within the `frontMatter.content.placeholders` setting. There are
+two types of placeholders you can create:
 
-- `static`: A static placeholder that will be replaced with a static value (you can use another placeholder in the value)
+- `static`: A static placeholder that will be replaced with a static value (you can use another
+  placeholder in the value)
 - `dynamic`: A dynamic placeholder that will use a script to generate the value
 
 ### Static placeholders
@@ -40,9 +44,11 @@ Here is an example of a static `permalink` placeholder:
 ]
 ```
 
-> **Info**: The static placeholder's value is adding some text and it will also include the slug of the page. There is no extra logic that is executed to generate the value.
+> **Info**: The static placeholder's value is adding some text and it will also include the slug of
+> the page. There is no extra logic that is executed to generate the value.
 
-To use the `permalink` placeholder, you need to define the `{{permalink}}` value in your content type or template.
+To use the `permalink` placeholder, you need to define the `{{permalink}}` value in your content
+type or template.
 
 ```json
 {
@@ -55,7 +61,9 @@ To use the `permalink` placeholder, you need to define the `{{permalink}}` value
 
 ### Dynamic placeholders
 
-Dynamic placeholders allow you to use custom scripts to generate the value. The difference with the static placeholder is that instead of specifying a value, you need to specify a `script` and `command` property.
+Dynamic placeholders allow you to use custom scripts to generate the value. The difference with the
+static placeholder is that instead of specifying a value, you need to specify a `script` and
+`command` property.
 
 #### Placeholder definition
 
@@ -87,15 +95,22 @@ if (arguments && arguments.length > 0) {
 }
 ```
 
-> **Info**: Like the other content scripts, you can use other types of scripts like Python, Bash, and more.
+> **Info**: Like the other content scripts, you can use other types of scripts like Python, Bash,
+> and more.
 
-The base script for a dynamic placeholder similar to the [content script](/docs/custom-actions/#content-script). The difference is that instead of retrieving the whole front matter object, you will receive the title. The reason is that the file is still not completely processed, and not all front matter fields are available.
+The base script for a dynamic placeholder similar to the
+[content script](/docs/custom-actions/#content-script). The difference is that instead of retrieving
+the whole front matter object, you will receive the title. The reason is that the file is still not
+completely processed, and not all front matter fields are available.
 
-> **Important**: In case you need to retrieve the whole front matter object, you can make use of the `postScript` property on your content type in combination with a [content script](/docs/custom-actions/#content-script).
+> **Important**: In case you need to retrieve the whole front matter object, you can make use of the
+> `postScript` property on your content type in combination with a
+> [content script](/docs/custom-actions/#content-script).
 
 #### Placeholder usage
 
-To use the `ogImage` placeholder, you need to define the `{{ogImage}}` value in your field as follows:
+To use the `ogImage` placeholder, you need to define the `{{ogImage}}` value in your field as
+follows:
 
 ```json
 {

--- a/content/docs/content-creation/placeholders.md
+++ b/content/docs/content-creation/placeholders.md
@@ -98,14 +98,12 @@ if (arguments && arguments.length > 0) {
 > **Info**: Like the other content scripts, you can use other types of scripts like Python, Bash,
 > and more.
 
-The base script for a dynamic placeholder similar to the
-[content script](/docs/custom-actions/#content-script). The difference is that instead of retrieving
-the whole front matter object, you will receive the title. The reason is that the file is still not
-completely processed, and not all front matter fields are available.
+The base script for a dynamic placeholder similar to the [content script][01]. The difference is
+that instead of retrieving the whole front matter object, you will receive the title. The reason is
+that the file is still not completely processed, and not all front matter fields are available.
 
 > **Important**: In case you need to retrieve the whole front matter object, you can make use of the
-> `postScript` property on your content type in combination with a
-> [content script](/docs/custom-actions/#content-script).
+> `postScript` property on your content type in combination with a [content script][01].
 
 #### Placeholder usage
 
@@ -120,3 +118,6 @@ follows:
   "default": "{{uniqueId}}"
 }
 ```
+
+<!-- Link References -->
+[01]: /docs/custom-actions/#content-script

--- a/content/docs/custom-actions.md
+++ b/content/docs/custom-actions.md
@@ -11,14 +11,18 @@ weight: 500
 
 ## Overview
 
-Not every website is the same. That is why we want to give you the ability to extend Front Matter and you can do this by adding your custom actions to the Front Matter panel. A custom action is nothing more than a Node.js script which is referenced from within your project.
+Not every website is the same. That is why we want to give you the ability to extend Front Matter
+and you can do this by adding your custom actions to the Front Matter panel. A custom action is
+nothing more than a Node.js script which is referenced from within your project.
 
 ![Custom action](/assets/custom-action.png)
 
-> **Sample**: [Generate open graph preview image in Code with Front Matter](https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/)
+<!-- markdownlint-disable MD028 -->
+> **Sample**:
+> [Generate open graph preview image in Code with Front Matter](https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/)
 
 > **Important**: You can add custom actions for your content and media files.
-
+<!-- markdownlint-enable MD028 -->
 ## The custom action setting
 
 The content and media custom actions can be defined by using the `frontMatter.custom.scripts` setting.
@@ -28,23 +32,30 @@ Custom actions can be configured with the following properties:
 - `id`: The id of the custom action/script
 - `title`: The title of the custom action
 - `script`: The path to the script to execute
-- `command`: The command to execute. Example: `node`, `path to your node executable`, `bash`, `python`, ... (default: `node` - optional).
-- `type`: The type for which the script will be used. Can be `content`, `mediaFile`, or `mediaFolder`. (default: `content` - optional).
+- `command`: The command to execute. Example: `node`, `path to your node executable`, `bash`,
+  `python`, ... (default: `node` - optional).
+- `type`: The type for which the script will be used. Can be `content`, `mediaFile`, or
+  `mediaFolder`. (default: `content` - optional).
 - `bulk`: Run the script for one file or multiple files. .
 - `output`: Specifies the output type (default: `notification` - optional). Available values are:
   - `notification`: The output will be passed as a notification.
   - `editor`: The output will be passed to the editor.
-- `outputType`: Specifies the output type (default: `text` - optional). Available values the editor values from VS Code like:
+- `outputType`: Specifies the output type (default: `text` - optional). Available values the editor
+  values from VS Code like:
   - `text`: The output will be passed as a text file.
   - `html`: The output will be passed as an HTML file.
   - `markdown`: The output will be passed as an Markdown file.
-- `hidden`: Hide the action from the UI. This is mostly used when creating a content script that will be used to post process new content (default: `false` - optional).
+- `hidden`: Hide the action from the UI. This is mostly used when creating a content script that
+  will be used to post process new content (default: `false` - optional).
 
-> **Important**: Previously, you could define the `nodeBin` property to define the path to your node executable. This path was needed when you are working with for instance `nvm` and have multiple versions of node installed. You can now use the `command` property instead.
+> **Important**: Previously, you could define the `nodeBin` property to define the path to your node
+> executable. This path was needed when you are working with for instance `nvm` and have multiple
+> versions of node installed. You can now use the `command` property instead.
 
 ## Creating a content script
 
-Create a folder in your project where you want to store all your custom scripts, and create a new JavaScript file. The sample content of this file looks like this:
+Create a folder in your project where you want to store all your custom scripts, and create a new
+JavaScript file. The sample content of this file looks like this:
 
 ```javascript
 const arguments = process.argv;
@@ -58,15 +69,18 @@ if (arguments && arguments.length > 0) {
 }
 ```
 
-> **Info**: The sample script can be found here [sample-script.js](https://github.com/estruyf/vscode-front-matter/blob/HEAD/sample/script-sample.js)
+> **Info**: The sample script can be found here
+> [sample-script.js](https://github.com/estruyf/vscode-front-matter/blob/HEAD/sample/script-sample.js)
 
-The current workspace-, file-path, and front matter data will be passed as a arguments. Like you can see in the above sample script, you can fetch these argument values as follows:
+The current workspace-, file-path, and front matter data will be passed as a arguments. Like you can
+see in the above sample script, you can fetch these argument values as follows:
 
 - `arguments[2]`: The workspace path
 - `arguments[3]`: The file path (Markdown file)
 - `arguments[4]`: The front matter data as object
 
-In order to use this functionality, you will need to configure the `frontMatter.custom.scripts` setting for your project as follows:
+In order to use this functionality, you will need to configure the `frontMatter.custom.scripts`
+setting for your project as follows:
 
 ```json
 {
@@ -78,15 +92,22 @@ In order to use this functionality, you will need to configure the `frontMatter.
 }
 ```
 
-> **Important**: When the command execution would fail when it cannot find the node command. You are able to specify your path to the node app. Command execution might for instance fail when using `nvm`. You can use the `command` property to specify the path to your node executable (*this is optional*).
+> **Important**: When the command execution would fail when it cannot find the node command. You are
+> able to specify your path to the node app. Command execution might for instance fail when using
+> `nvm`. You can use the `command` property to specify the path to your node executable (_this is
+> optional_).
 
-Once a custom action has been configured, it will appear on the Front Matter panel. The output of the script will be passed as a notification in VS Code. This output allows you to copy the output, useful when you generate additional content.
+Once a custom action has been configured, it will appear on the Front Matter panel. The output of
+the script will be passed as a notification in VS Code. This output allows you to copy the output,
+useful when you generate additional content.
 
 ![Custom action output](/assets/custom-action-output.png)
 
 ### Updating the front matter
 
-By default, once a custom action executed, it will show the output in a notification. In case you want to update the front matter of your content, you need to provide the data in the following JSON format.
+By default, once a custom action executed, it will show the output in a notification. In case you
+want to update the front matter of your content, you need to provide the data in the following JSON
+format.
 
 ```json
 { "frontmatter": { "<field name>": "field value" }}
@@ -98,7 +119,8 @@ Example:
 (async () => {
     // Your script logic
 
-    // Finally, update the front matter of your content by passing the data in the following format
+    // Finally, update the front matter of your content by passing the data
+    // in the following format
     const output = JSON.stringify({
       "frontmatter": {
         "title": "My new title"
@@ -110,13 +132,16 @@ Example:
 })();
 ```
 
-When data is passed in the above format, it will automatically get parse the JSON data and the file its front matter gets updated accordingly.
+When data is passed in the above format, it will automatically get parse the JSON data and the file
+its front matter gets updated accordingly.
 
 ## Bulk script execution
 
-If you want, you can run a script for multiple files at once. This is useful when you want to generate a social image for all your markdown files or perform any other bulk operation.
+If you want, you can run a script for multiple files at once. This is useful when you want to
+generate a social image for all your markdown files or perform any other bulk operation.
 
-To enable bulk script execution, you need to configure the `frontMatter.custom.scripts` setting for your project as follows:
+To enable bulk script execution, you need to configure the `frontMatter.custom.scripts` setting for
+your project as follows:
 
 ```json
 {
@@ -130,13 +155,18 @@ To enable bulk script execution, you need to configure the `frontMatter.custom.s
 }
 ```
 
-> **Important**: The `bulk` property is what specifies if it is a script that should be executed for multiple files.
+> **Important**: The `bulk` property is what specifies if it is a script that should be executed for
+> multiple files.
 
 ## Creating a media script
 
-Creating a media script is similar to creating a content script. The only difference is that you need to specify the `type` property. You can use the `mediaFile` or `mediaFolder` as the value for the `type` property.
+Creating a media script is similar to creating a content script. The only difference is that you
+need to specify the `type` property. You can use the `mediaFile` or `mediaFolder` as the value for
+the `type` property.
 
-Like the name suggests, the `mediaFile` type will be used for scripts that should be executed for a single media file. The `mediaFolder` type will be used for scripts that should be executed for all media files in a folder.
+Like the name suggests, the `mediaFile` type will be used for scripts that should be executed for a
+single media file. The `mediaFolder` type will be used for scripts that should be executed for all
+media files in a folder.
 
 Here is a sample on how you can define a media script:
 
@@ -166,13 +196,15 @@ The current workspace-, file/folder-path will be passed as a arguments.
 
 ### Media file script
 
-When you defined a media file script, you will be able to execute it for a single media file from its menu.
+When you defined a media file script, you will be able to execute it for a single media file from
+its menu.
 
 ![Custom action for a media file](/releases/v5.6.0/media-file-custom-script.png)
 
 ### Media folder script
 
-When you defined a media folder script, you will be able to execute it for all media files in the menu next to the **create new folder** button.
+When you defined a media folder script, you will be able to execute it for all media files in the
+menu next to the **create new folder** button.
 
 ![Custom action for a media folder](/releases/v5.6.0/media-folder-custom-script.png)
 
@@ -210,9 +242,9 @@ const arguments = process.argv;
     const imagemin = (await import('imagemin')).default;
     const imageminJpegtran = (await import('imagemin-jpegtran')).default;
     const imageminPngquant = (await import('imagemin-pngquant')).default;
-    
+
     const fileArg = arguments[3]; // The file path
-  
+
     await imagemin([fileArg], {
       destination: path.dirname(fileArg),
       glob: false,
@@ -246,7 +278,7 @@ const arguments = process.argv;
 
     const workspaceArg = arguments[2]; // The workspace path
     const folderArg = arguments[3]; // The folder path
-  
+
     const files = await imagemin([path.join(folderArg, '*.{jpg,png}')], {
       destination: folderArg,
       glob: true,

--- a/content/docs/custom-actions.md
+++ b/content/docs/custom-actions.md
@@ -15,11 +15,10 @@ Not every website is the same. That is why we want to give you the ability to ex
 and you can do this by adding your custom actions to the Front Matter panel. A custom action is
 nothing more than a Node.js script which is referenced from within your project.
 
-![Custom action](/assets/custom-action.png)
+![Custom action][01]
 
 <!-- markdownlint-disable MD028 -->
-> **Sample**:
-> [Generate open graph preview image in Code with Front Matter](https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/)
+> **Sample**: [Generate open graph preview image in Code with Front Matter][02]
 
 > **Important**: You can add custom actions for your content and media files.
 <!-- markdownlint-enable MD028 -->
@@ -69,8 +68,7 @@ if (arguments && arguments.length > 0) {
 }
 ```
 
-> **Info**: The sample script can be found here
-> [sample-script.js](https://github.com/estruyf/vscode-front-matter/blob/HEAD/sample/script-sample.js)
+> **Info**: The sample script can be found here [sample-script.js][03]
 
 The current workspace-, file-path, and front matter data will be passed as a arguments. Like you can
 see in the above sample script, you can fetch these argument values as follows:
@@ -101,7 +99,7 @@ Once a custom action has been configured, it will appear on the Front Matter pan
 the script will be passed as a notification in VS Code. This output allows you to copy the output,
 useful when you generate additional content.
 
-![Custom action output](/assets/custom-action-output.png)
+![Custom action output][04]
 
 ### Updating the front matter
 
@@ -199,14 +197,14 @@ The current workspace-, file/folder-path will be passed as a arguments.
 When you defined a media file script, you will be able to execute it for a single media file from
 its menu.
 
-![Custom action for a media file](/releases/v5.6.0/media-file-custom-script.png)
+![Custom action for a media file][05]
 
 ### Media folder script
 
 When you defined a media folder script, you will be able to execute it for all media files in the
 menu next to the **create new folder** button.
 
-![Custom action for a media folder](/releases/v5.6.0/media-folder-custom-script.png)
+![Custom action for a media folder][06]
 
 ## Sample scripts
 
@@ -296,3 +294,11 @@ const arguments = process.argv;
 **Prerequisites**:
 
 - `npm i imagemin imagemin-jpegtran imagemin-pngquant`
+
+<!-- Link References -->
+[01]: /assets/custom-action.png
+[02]: https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/
+[03]: https://github.com/estruyf/vscode-front-matter/blob/HEAD/sample/script-sample.js
+[04]: /assets/custom-action-output.png
+[05]: /releases/v5.6.0/media-file-custom-script.png
+[06]: /releases/v5.6.0/media-folder-custom-script.png

--- a/content/docs/dashboard.md
+++ b/content/docs/dashboard.md
@@ -11,43 +11,51 @@ weight: 300
 
 ## Overview
 
-Managing your Markdown pages/media has never been easier in VS Code. With the Front Matter dashboard, you will be able to view all your pages and media.
+Managing your Markdown pages/media has never been easier in VS Code. With the Front Matter
+dashboard, you will be able to view all your pages and media.
 
 On the contents view, you can **search**, **filter**, **sort** your pages and much more.
 
 ![Dashboard - Contents view](/releases/v7.1.0/dashboard-7.1.0.png)
 
-On the media view, you can quickly glance all the available media files in your project and perform quick actions like copying the relative path.
+On the media view, you can quickly glance all the available media files in your project and perform
+quick actions like copying the relative path.
 
 ![Dashboard - Media view](/releases/v7.1.0/dashboard-media.png)
 
-In order to start using the dashboard, you will have to let the extension know in which folder(s) it can find your pages. Be sure to follow our [getting started](/docs/getting-started) guide.
+In order to start using the dashboard, you will have to let the extension know in which folder(s) it
+can find your pages. Be sure to follow our [getting started](/docs/getting-started) guide.
 
-> **Important**: If your preview images are not loading, it might be that you need to configure the `publicFolder` where the extension can find them. For instance, in Hugo, this is the static folder. You can configure this by updating the `frontMatter.content.publicFolder` setting.
+> **Important**: If your preview images are not loading, it might be that you need to configure the
+> `publicFolder` where the extension can find them. For instance, in Hugo, this is the static
+> folder. You can configure this by updating the `frontMatter.content.publicFolder` setting.
 
 ## Commands
 
 There are the following commands to open the dashboards:
 
-| Command title | Command id | Description |
-| --- | --- | --- |
-| Front matter: Open dashboard | `frontMatter.dashboard` | Opens the dashboard on the contents view. |
-| Front matter: Open media dashboard | `frontMatter.dashboard.media` | Opens the dashboard on the media view. |
-| Front matter: Open snippets dashboard | `frontMatter.dashboard.snippets` | Opens the dashboard on the snippets view. |
-| Front matter: Open data dashboard | `frontMatter.dashboard.data` | Opens the dashboard on the data view. |
+| Command title                           | Command id                       | Description                                 |
+| --------------------------------------- | -------------------------------- | ------------------------------------------- |
+| Front matter: Open dashboard            | `frontMatter.dashboard`          | Opens the dashboard on the contents view.   |
+| Front matter: Open media dashboard      | `frontMatter.dashboard.media`    | Opens the dashboard on the media view.      |
+| Front matter: Open snippets dashboard   | `frontMatter.dashboard.snippets` | Opens the dashboard on the snippets view.   |
+| Front matter: Open data dashboard       | `frontMatter.dashboard.data`     | Opens the dashboard on the data view.       |
 | Front matter: Open taxonomies dashboard | `frontMatter.dashboard.taxonomy` | Opens the dashboard on the taxonomies view. |
 
 ## Contents view
 
 ### Card tags
 
-The tags underneath the content abstract/description is changable. By default, the card will show the value of the `tags` field, but you can update the field by specifying the value in the `frontMatter.dashboard.content.cardTags` setting.
+The tags underneath the content abstract/description is changable. By default, the card will show
+the value of the `tags` field, but you can update the field by specifying the value in the
+`frontMatter.dashboard.content.cardTags` setting.
 
 ![Card tags](/releases/v7.1.0/card-tags.png)
 
 ### Draft status navigation
 
-By default, the contents view will show all your pages, and will you will be able to filter by **draft** and **published** pages.
+By default, the contents view will show all your pages, and will you will be able to filter by
+**draft** and **published** pages.
 
 ![Draft filters](/releases/v7.1.0/draft-filters.png)
 
@@ -68,29 +76,39 @@ If you want to use other statuses, you can do so by specifying your own draft fi
 - Last modified
 - Filename (asc/desc)
 
-> **Info**: You can define custom sorting options by specifying these within the [frontMatter.content.sorting](/docs/settings#frontmatter.content.sorting) setting.
+> **Info**: You can define custom sorting options by specifying these within the
+> [frontMatter.content.sorting](/docs/settings#frontmatter.content.sorting) setting.
 
-You are also able to define your default sorting options by setting the `frontMatter.content.defaultSorting` setting for the content view, and the `frontMatter.media.defaultSorting` setting for the media view.
+You are also able to define your default sorting options by setting the
+`frontMatter.content.defaultSorting` setting for the content view, and the
+`frontMatter.media.defaultSorting` setting for the media view.
 
 ### Show on startup
 
-If you want, you can check on the `Open on startup?` checkbox. This setting will allow the dashboard to automatically open when you launch the project in VS Code. It will only apply to the current project, not for all of them.
+If you want, you can check on the `Open on startup?` checkbox. This setting will allow the dashboard
+to automatically open when you launch the project in VS Code. It will only apply to the current
+project, not for all of them.
 
 ### Content pagination
 
-By default, the content is paginated by 16 items. If you want, you can disable the pagination by setting the `frontMatter.dashboard.content.pagination` setting to `false`.
+By default, the content is paginated by 16 items. If you want, you can disable the pagination by
+setting the `frontMatter.dashboard.content.pagination` setting to `false`.
 
 ## Media view
 
-The media view has been created to make it easier to look at all media files available for your articles. When you click on an image, it will show a lightbox, so that it is easier to glance at small images.
+The media view has been created to make it easier to look at all media files available for your
+articles. When you click on an image, it will show a lightbox, so that it is easier to glance at
+small images.
 
 ![Dashboard - Media view - Lightbox](/releases/v5.9.0/media-lightbox.png)
 
 ### Supported files
 
-By default, the media dashboard supports audio, image, and video files to be displayed and uploaded (drag&drop).
+By default, the media dashboard supports audio, image, and video files to be displayed and uploaded
+(drag&drop).
 
-If you want that the media dashboard supports additional file types, you can define these in the `frontMatter.media.supportedMimeTypes` setting.
+If you want that the media dashboard supports additional file types, you can define these in the
+`frontMatter.media.supportedMimeTypes` setting.
 
 ```json
 "frontMatter.media.supportedMimeTypes": [
@@ -102,25 +120,32 @@ If you want that the media dashboard supports additional file types, you can def
 
 ### Media actions
 
-On the image card, there are actions like setting metadata, copying the relative path, and deleting the media file.
+On the image card, there are actions like setting metadata, copying the relative path, and deleting
+the media file.
 
-**Setting metadata**
+#### Setting metadata
 
-Setting metadata got introduced so that you can set the description and alt tag of your images. This functionality makes it easier to insert your images to your content.
+Setting metadata got introduced so that you can set the description and alt tag of your images. This
+functionality makes it easier to insert your images to your content.
 
 ![Dashboard - Setting metadata](/releases/v5.0.0/metadata-media.png)
 
+<!-- markdownlint-disable MD028 -->
 > **Info**: Check the [Insert images section](/docs/markdown#insert-images) for more information.
 
-> **Important**: Data is stored in a local JSON file which you can find under: `<project>/.frontmatter/content/mediaDb.json`. Please do not remove this file, or you will lose your metadata.
+> **Important**: Data is stored in a local JSON file which you can find under:
+> `<project>/.frontmatter/content/mediaDb.json`. Please do not remove this file, or you will lose
+> your metadata.
+<!-- markdownlint-enable MD028 -->
 
-**Deleting a media file**
+#### Deleting a media file
 
 ![Dashboard - Delete media file](/releases/v5.9.0/media-deletion.png)
 
-**Custom media actions**
+#### Custom media actions
 
-In version `5.6.0` of the extension, you can now define your own media actions. This extensibility option is very useful for adding your own optimizations, functionality, or anything else you want.
+In version `5.6.0` of the extension, you can now define your own media actions. This extensibility
+option is very useful for adding your own optimizations, functionality, or anything else you want.
 
 For instance, you can use it to optimize the image(s) size.
 
@@ -129,17 +154,21 @@ Custom actions for media files can be defined on two levels:
 - File level: Single file action
 - Folder level: Multiple files action
 
-> **Info**: Check out [creating media scripts](/docs/custom-actions#creating-a-media-script) for more information.
+> **Info**: Check out [creating media scripts](/docs/custom-actions#creating-a-media-script) for
+> more information.
 
 ### Drag and Drop
 
-On the media view, we enabled drag and drop for your media files. You can easily drop any image from your explorer/finder window into one of your folders.
+On the media view, we enabled drag and drop for your media files. You can easily drop any image from
+your explorer/finder window into one of your folders.
 
 ![Dashboard - Upload media file](/releases/v5.9.0/media-upload.png)
 
 ## Data files view
 
-Data files/folders are pieces of content that do not belong to any markdown content, but live on their own. Most of the time, these data files are used to store additional information about your project/blog/website that will be used to render the content.
+Data files/folders are pieces of content that do not belong to any markdown content, but live on
+their own. Most of the time, these data files are used to store additional information about your
+project/blog/website that will be used to render the content.
 
 For example: navigation, social media links, contacts, etc.
 
@@ -149,15 +178,17 @@ The data files dashboard allows you to quickly manage your data files.
 
 ### Configuration
 
-In order to use the data files dashboard, you will need to configure the extension with the following settings:
+In order to use the data files dashboard, you will need to configure the extension with the
+following settings:
 
-- `frontMatter.data.types`: This only defines the object and its fields. Use this setting, if you want to re-use a data type in various files/folders.
+- `frontMatter.data.types`: This only defines the object and its fields. Use this setting, if you
+  want to re-use a data type in various files/folders.
 - `frontMatter.data.files`: Defines how a single data file.
 - `frontMatter.data.folders`: Defines that all files of a folder need to be treated the same.
 
 ### Creating a data file
 
-To create a data file, you can use the `frontMatter.data.files` setting. 
+To create a data file, you can use the `frontMatter.data.files` setting.
 
 ```json
 "frontMatter.data.files": [
@@ -193,17 +224,23 @@ To create a data file, you can use the `frontMatter.data.files` setting.
 ]
 ```
 
-The above sample can be used to create a sponsor data file which contains an array of sponsor object with url, name, and description as properties.
+The above sample can be used to create a sponsor data file which contains an array of sponsor object
+with url, name, and description as properties.
 
 ![Data dashboard - Sponsor example](/releases/v6.0.0/data-dashboard-sample.png)
 
-> **Info**: Use the `[[workspace]]` placeholder to define the workspace folder. The extension will automatically replace this with the workspace folder path.
+<!-- markdownlint-disable MD028 -->
+> **Info**: Use the `[[workspace]]` placeholder to define the workspace folder. The extension will
+> automatically replace this with the workspace folder path.
 
-> **Important**: In the `schema` property we use the [JSON Schema](https://json-schema.org/) standard to define the structure of the data file.
-
+> **Important**: In the `schema` property we use the [JSON Schema](https://json-schema.org/)
+> standard to define the structure of the data file.
+<!-- markdownlint-enable MD028 -->
 ### Re-using a data type for files or folders
 
-In some cases, you might want to re-use a data type for files or folders. You can do so by using the `frontMatter.data.types` setting in combination with the `frontMatter.data.files` and/or `frontMatter.data.folders` settings.
+In some cases, you might want to re-use a data type for files or folders. You can do so by using the
+`frontMatter.data.types` setting in combination with the `frontMatter.data.files` and/or
+`frontMatter.data.folders` settings.
 
 First the data type, this is an object containing the `id` and `schema` properties.
 
@@ -237,7 +274,8 @@ First the data type, this is an object containing the `id` and `schema` properti
 ]
 ```
 
-In the `frontMatter.data.files` and/or `frontMatter.data.folders` settings, instead of defining the `schema` property, you can use the `type` property to reference the data type.
+In the `frontMatter.data.files` and/or `frontMatter.data.folders` settings, instead of defining the
+`schema` property, you can use the `type` property to reference the data type.
 
 ```json
 "frontMatter.data.files": [
@@ -251,14 +289,16 @@ In the `frontMatter.data.files` and/or `frontMatter.data.folders` settings, inst
 ]
 ```
 
-> **Important**: when using data folders, the extension searches for `yml`, `yaml`, and `json` files in the folder.
-
+> **Important**: when using data folders, the extension searches for `yml`, `yaml`, and `json` files
+> in the folder.
 
 ## Taxonomies view
 
-The taxonomies view is a powerful way to manage your taxonomy like categories, tags, or any other taxonomy. 
+The taxonomies view is a powerful way to manage your taxonomy like categories, tags, or any other
+taxonomy.
 
-On the taxonomies view, you can create, edit, delete, and move taxonomy terms from one type to another.
+On the taxonomies view, you can create, edit, delete, and move taxonomy terms from one type to
+another.
 
 ![Taxonomies view](/releases/v8.1.0/taxonomies-view.png)
 
@@ -268,8 +308,11 @@ On the taxonomies view, you can create, edit, delete, and move taxonomy terms fr
 
 You can perform the following actions on the taxonomies view:
 
-- **Add**: If a taxonomy value is not yet stored in your settings, the `+` add action is shown to allow you a quick way to store the value;
+- **Add**: If a taxonomy value is not yet stored in your settings, the `+` add action is shown to
+  allow you a quick way to store the value;
 - **Edit**: Edit the taxonomy value in the settings + all the files where it is used;
-- **Merge**: Merge two taxonomy values into one. For instance, if you have `dev` and `development` you can merge `dev` into `development` and it will update all the files where it is used;
-- **Move**: Move a taxonomy value to another type. For instance, if you want to move a tag to a category;
+- **Merge**: Merge two taxonomy values into one. For instance, if you have `dev` and `development`
+  you can merge `dev` into `development` and it will update all the files where it is used;
+- **Move**: Move a taxonomy value to another type. For instance, if you want to move a tag to a
+  category;
 - **Delete**: Delete a taxonomy value.

--- a/content/docs/dashboard.md
+++ b/content/docs/dashboard.md
@@ -16,15 +16,15 @@ dashboard, you will be able to view all your pages and media.
 
 On the contents view, you can **search**, **filter**, **sort** your pages and much more.
 
-![Dashboard - Contents view](/releases/v7.1.0/dashboard-7.1.0.png)
+![Dashboard - Contents view][01]
 
 On the media view, you can quickly glance all the available media files in your project and perform
 quick actions like copying the relative path.
 
-![Dashboard - Media view](/releases/v7.1.0/dashboard-media.png)
+![Dashboard - Media view][02]
 
 In order to start using the dashboard, you will have to let the extension know in which folder(s) it
-can find your pages. Be sure to follow our [getting started](/docs/getting-started) guide.
+can find your pages. Be sure to follow our [getting started][03] guide.
 
 > **Important**: If your preview images are not loading, it might be that you need to configure the
 > `publicFolder` where the extension can find them. For instance, in Hugo, this is the static
@@ -50,20 +50,20 @@ The tags underneath the content abstract/description is changable. By default, t
 the value of the `tags` field, but you can update the field by specifying the value in the
 `frontMatter.dashboard.content.cardTags` setting.
 
-![Card tags](/releases/v7.1.0/card-tags.png)
+![Card tags][04]
 
 ### Draft status navigation
 
 By default, the contents view will show all your pages, and will you will be able to filter by
 **draft** and **published** pages.
 
-![Draft filters](/releases/v7.1.0/draft-filters.png)
+![Draft filters][05]
 
 If you want to use other statuses, you can do so by specifying your own draft field and value.
 
-> **Info**: [Set a custom draft field](/docs/content-creation/fields#draft).
+> **Info**: [Set a custom draft field][06].
 
-![Draft filters](/releases/v5.3.0/draft-status.png)
+![Draft filters][07]
 
 ### Supported filters
 
@@ -77,7 +77,7 @@ If you want to use other statuses, you can do so by specifying your own draft fi
 - Filename (asc/desc)
 
 > **Info**: You can define custom sorting options by specifying these within the
-> [frontMatter.content.sorting](/docs/settings#frontmatter.content.sorting) setting.
+> [frontMatter.content.sorting][08] setting.
 
 You are also able to define your default sorting options by setting the
 `frontMatter.content.defaultSorting` setting for the content view, and the
@@ -100,7 +100,7 @@ The media view has been created to make it easier to look at all media files ava
 articles. When you click on an image, it will show a lightbox, so that it is easier to glance at
 small images.
 
-![Dashboard - Media view - Lightbox](/releases/v5.9.0/media-lightbox.png)
+![Dashboard - Media view - Lightbox][09]
 
 ### Supported files
 
@@ -128,10 +128,10 @@ the media file.
 Setting metadata got introduced so that you can set the description and alt tag of your images. This
 functionality makes it easier to insert your images to your content.
 
-![Dashboard - Setting metadata](/releases/v5.0.0/metadata-media.png)
+![Dashboard - Setting metadata][10]
 
 <!-- markdownlint-disable MD028 -->
-> **Info**: Check the [Insert images section](/docs/markdown#insert-images) for more information.
+> **Info**: Check the [Insert images section][11] for more information.
 
 > **Important**: Data is stored in a local JSON file which you can find under:
 > `<project>/.frontmatter/content/mediaDb.json`. Please do not remove this file, or you will lose
@@ -140,7 +140,7 @@ functionality makes it easier to insert your images to your content.
 
 #### Deleting a media file
 
-![Dashboard - Delete media file](/releases/v5.9.0/media-deletion.png)
+![Dashboard - Delete media file][12]
 
 #### Custom media actions
 
@@ -154,15 +154,14 @@ Custom actions for media files can be defined on two levels:
 - File level: Single file action
 - Folder level: Multiple files action
 
-> **Info**: Check out [creating media scripts](/docs/custom-actions#creating-a-media-script) for
-> more information.
+> **Info**: Check out [creating media scripts][13] for more information.
 
 ### Drag and Drop
 
 On the media view, we enabled drag and drop for your media files. You can easily drop any image from
 your explorer/finder window into one of your folders.
 
-![Dashboard - Upload media file](/releases/v5.9.0/media-upload.png)
+![Dashboard - Upload media file][14]
 
 ## Data files view
 
@@ -174,7 +173,7 @@ For example: navigation, social media links, contacts, etc.
 
 The data files dashboard allows you to quickly manage your data files.
 
-![Data files dashboard](/releases/v6.0.0/data-files-dashboard.png)
+![Data files dashboard][15]
 
 ### Configuration
 
@@ -227,14 +226,14 @@ To create a data file, you can use the `frontMatter.data.files` setting.
 The above sample can be used to create a sponsor data file which contains an array of sponsor object
 with url, name, and description as properties.
 
-![Data dashboard - Sponsor example](/releases/v6.0.0/data-dashboard-sample.png)
+![Data dashboard - Sponsor example][16]
 
 <!-- markdownlint-disable MD028 -->
 > **Info**: Use the `[[workspace]]` placeholder to define the workspace folder. The extension will
 > automatically replace this with the workspace folder path.
 
-> **Important**: In the `schema` property we use the [JSON Schema](https://json-schema.org/)
-> standard to define the structure of the data file.
+> **Important**: In the `schema` property we use the [JSON Schema][17] standard to define the
+> structure of the data file.
 <!-- markdownlint-enable MD028 -->
 ### Re-using a data type for files or folders
 
@@ -300,11 +299,11 @@ taxonomy.
 On the taxonomies view, you can create, edit, delete, and move taxonomy terms from one type to
 another.
 
-![Taxonomies view](/releases/v8.1.0/taxonomies-view.png)
+![Taxonomies view][18]
 
 ### Actions
 
-![Taxonomy actions](/releases/v8.0.0/taxonomy-actions.png)
+![Taxonomy actions][19]
 
 You can perform the following actions on the taxonomies view:
 
@@ -316,3 +315,24 @@ You can perform the following actions on the taxonomies view:
 - **Move**: Move a taxonomy value to another type. For instance, if you want to move a tag to a
   category;
 - **Delete**: Delete a taxonomy value.
+
+<!-- Link References -->
+[01]: /releases/v7.1.0/dashboard-7.1.0.png
+[02]: /releases/v7.1.0/dashboard-media.png
+[03]: /docs/getting-started
+[04]: /releases/v7.1.0/card-tags.png
+[05]: /releases/v7.1.0/draft-filters.png
+[06]: /docs/content-creation/fields#draft
+[07]: /releases/v5.3.0/draft-status.png
+[08]: /docs/settings#frontmatter.content.sorting
+[09]: /releases/v5.9.0/media-lightbox.png
+[10]: /releases/v5.0.0/metadata-media.png
+[11]: /docs/markdown#insert-images
+[12]: /releases/v5.9.0/media-deletion.png
+[13]: /docs/custom-actions#creating-a-media-script
+[14]: /releases/v5.9.0/media-upload.png
+[15]: /releases/v6.0.0/data-files-dashboard.png
+[16]: /releases/v6.0.0/data-dashboard-sample.png
+[17]: https://json-schema.org/
+[18]: /releases/v8.1.0/taxonomies-view.png
+[19]: /releases/v8.0.0/taxonomy-actions.png

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -11,11 +11,13 @@ weight: 100
 
 ## Overview
 
-To get you started, you first need to install the extension in Visual Studio Code. 
+To get you started, you first need to install the extension in Visual Studio Code.
 
 ## Installation
 
 You can get the extension via:
+
+<!-- markdownlint-disable MD033 MD013 MD028 -->
 
 - The VS Code marketplace: [VS Code Marketplace - Front Matter](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter).
 - The extension CLI: `ext install eliostruyf.vscode-front-matter`
@@ -23,7 +25,8 @@ You can get the extension via:
 
 ### Beta version
 
-If you have the courage to test out the beta features, we made available a beta version as well. You can install this via:
+If you have the courage to test out the beta features, we made available a beta version as well. You
+can install this via:
 
 - The VS Code marketplace: [VS Code Marketplace - Front Matter BETA](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter-beta).
 - The extension CLI: `ext install eliostruyf.vscode-front-matter-beta`
@@ -31,51 +34,69 @@ If you have the courage to test out the beta features, we made available a beta 
 
 > **Info**: The BETA docs can be found on [beta.frontmatter.codes](https://beta.frontmatter.codes).
 
-> **Important**: As there can only be one version running of the extension, you will need to uninstall the main version before installing the beta version.
+> **Important**: As there can only be one version running of the extension, you will need to
+> uninstall the main version before installing the beta version.
 
 ## Welcome screen
 
-Once installed, Front Matter will open the **welcome screen** the first time Visual Studio Code gets reloaded.
+Once installed, Front Matter will open the **welcome screen** the first time Visual Studio Code gets
+reloaded.
 
 ![Welcome screen to configure your website](/releases/v7.2.0/welcome-screen-7.2.0.png)
 
-> **Important**: Front Matter supports light and dark mode. It will be automatically detected based on the theme you are using.
+> **Important**: Front Matter supports light and dark mode. It will be automatically detected based
+> on the theme you are using.
 
 > **Info**: The welcome screen will also be shown when Front Matter is not yet fully configured.
 
 ## Required configuration
 
-On the welcome screen, there are two tasks to complete before you can take full advantage of Front Matter. 
+On the welcome screen, there are two tasks to complete before you can take full advantage of Front Matter.
 
 ### Step 1: Initialize the project
 
-In this step, a `.frontmatter/templates` folder and `article.md` file template will be created in the current project.
+In this step, a `.frontmatter/templates` folder and `article.md` file template will be created in
+the current project.
 
-The `.frontmatter/templates` folder, is a folder that can be used to place all sort of Markdown templates. It will be used when you want to let Front Matter generate new pages/articles/...
+The `.frontmatter/templates` folder, is a folder that can be used to place all sort of Markdown
+templates. It will be used when you want to let Front Matter generate new pages/articles/...
 
 ### Step 2: Configure the site-generator or framework you use
 
-In this step, you will need to configure the site-generator or framework you use. If your static-site-generator is known by Front Matter, it will automatically set some configuration options. If not, you will need to configure these settings manually. You can continue by selecting `other` from the dropdown.
+In this step, you will need to configure the site-generator or framework you use. If your
+static-site-generator is known by Front Matter, it will automatically set some configuration
+options. If not, you will need to configure these settings manually. You can continue by selecting
+`other` from the dropdown.
 
 ### Step 3: Register content folder(s)
 
-As Front Matter is created to support many (or all) static site generator, you will need to specify where your Markdown/content lives. From the moment you register a folder, it will be used on the dashboard to show an overview of all files.
+As Front Matter is created to support many (or all) static site generator, you will need to specify
+where your Markdown/content lives. From the moment you register a folder, it will be used on the
+dashboard to show an overview of all files.
 
-Registering a folder can be done from the list of folders Front Matter has found that already contains supported files.
+Registering a folder can be done from the list of folders Front Matter has found that already
+contains supported files.
 
 ![Content folders](/releases/v7.2.0/content-list.png)
 
-If one of your folders is not shown, you can register it by right-clicking on a folder name in the explorer panel from Visual Studio Code and selecting **Front Matter: Register folder**.
+If one of your folders is not shown, you can register it by right-clicking on a folder name in the
+explorer panel from Visual Studio Code and selecting **Front Matter: Register folder**.
 
 ![Register a folder](/assets/register-folder.png)
 
-> **Info**: Be default, the extension will include content from the current folder and its sub-folders. If you wish to exclude the sub-folders, you can do this by updating the [frontMatter.content.pageFolders](/docs/settings#frontmatter.content.pagefolders) configuration setting and specifying the `excludeSubDir` property with the value as `true`.
+> **Info**: Be default, the extension will include content from the current folder and its
+> sub-folders. If you wish to exclude the sub-folders, you can do this by updating the
+> [frontMatter.content.pageFolders](/docs/settings#frontmatter.content.pagefolders) configuration
+> setting and specifying the `excludeSubDir` property with the value as `true`.
 
 ## Workspaces with multiple folders
 
-If you are using workspaces with multiple folders in Visual Studio Code. Front Matter will try to figure out for which folder it needs to be activated. It does this by searching for the `frontmatter.json` file in the workspace folders.
+If you are using workspaces with multiple folders in Visual Studio Code. Front Matter will try to
+figure out for which folder it needs to be activated. It does this by searching for the
+`frontmatter.json` file in the workspace folders.
 
-When Front Matter cannot find a `frontmatter.json` file in any of your folders (means that it is not initiated yet), it will ask you to pick the folder.
+When Front Matter cannot find a `frontmatter.json` file in any of your folders (means that it is not
+initiated yet), it will ask you to pick the folder.
 
 ![Select your workspace folder for Front Matter](/releases/v5.0.0/workspace-folder.png)
 
@@ -83,7 +104,9 @@ Once you selected the folder, it will create the `frontmatter.json` file and rel
 
 ## Backers & supporters
 
-If you are one of the Front Matter supporters/backers, you can hide the support links from the UI. We know it is not much, but we want to give something small back, and what is better than a bit of space? 🤓
+If you are one of the Front Matter supporters/backers, you can hide the support links from the UI.
+We know it is not much, but we want to give something small back, and what is better than a bit of
+space? 🤓
 
 By default, you'll see the following support links:
 
@@ -93,7 +116,8 @@ When you log in via GitHub, you'll see the following:
 
 ![Hidden support links](/releases/v6.0.0/support-links-hidden.png)
 
-Simply start by clicking on the **Accounts** button, and select **Sign in with GitHub to use Front Matter** or launch the same flow by using the `Front Matter: Authenticate` command.
+Simply start by clicking on the **Accounts** button, and select **Sign in with GitHub to use Front
+Matter** or launch the same flow by using the `Front Matter: Authenticate` command.
 
 ![Sign in with GitHub for Front Matter](/releases/v6.0.0/signin-github.png)
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -19,7 +19,7 @@ You can get the extension via:
 
 <!-- markdownlint-disable MD033 MD013 MD028 -->
 
-- The VS Code marketplace: [VS Code Marketplace - Front Matter](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter).
+- The VS Code marketplace: [VS Code Marketplace - Front Matter][01].
 - The extension CLI: `ext install eliostruyf.vscode-front-matter`
 - Or by clicking on the following link: <a href="" title="open extension in VS Code" data-vscode="vscode:extension/eliostruyf.vscode-front-matter">open extension in VS Code</a>
 
@@ -28,11 +28,11 @@ You can get the extension via:
 If you have the courage to test out the beta features, we made available a beta version as well. You
 can install this via:
 
-- The VS Code marketplace: [VS Code Marketplace - Front Matter BETA](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter-beta).
+- The VS Code marketplace: [VS Code Marketplace - Front Matter BETA][02].
 - The extension CLI: `ext install eliostruyf.vscode-front-matter-beta`
 - Or by clicking on the following link: <a href="" title="open extension in VS Code" data-vscode="vscode:extension/eliostruyf.vscode-front-matter-beta">open extension in VS Code</a>
 
-> **Info**: The BETA docs can be found on [beta.frontmatter.codes](https://beta.frontmatter.codes).
+> **Info**: The BETA docs can be found on [beta.frontmatter.codes][03].
 
 > **Important**: As there can only be one version running of the extension, you will need to
 > uninstall the main version before installing the beta version.
@@ -42,7 +42,7 @@ can install this via:
 Once installed, Front Matter will open the **welcome screen** the first time Visual Studio Code gets
 reloaded.
 
-![Welcome screen to configure your website](/releases/v7.2.0/welcome-screen-7.2.0.png)
+![Welcome screen to configure your website][04]
 
 > **Important**: Front Matter supports light and dark mode. It will be automatically detected based
 > on the theme you are using.
@@ -77,17 +77,17 @@ dashboard to show an overview of all files.
 Registering a folder can be done from the list of folders Front Matter has found that already
 contains supported files.
 
-![Content folders](/releases/v7.2.0/content-list.png)
+![Content folders][05]
 
 If one of your folders is not shown, you can register it by right-clicking on a folder name in the
 explorer panel from Visual Studio Code and selecting **Front Matter: Register folder**.
 
-![Register a folder](/assets/register-folder.png)
+![Register a folder][06]
 
 > **Info**: Be default, the extension will include content from the current folder and its
 > sub-folders. If you wish to exclude the sub-folders, you can do this by updating the
-> [frontMatter.content.pageFolders](/docs/settings#frontmatter.content.pagefolders) configuration
-> setting and specifying the `excludeSubDir` property with the value as `true`.
+> [frontMatter.content.pageFolders][07] configuration setting and specifying the `excludeSubDir`
+> property with the value as `true`.
 
 ## Workspaces with multiple folders
 
@@ -98,7 +98,7 @@ figure out for which folder it needs to be activated. It does this by searching 
 When Front Matter cannot find a `frontmatter.json` file in any of your folders (means that it is not
 initiated yet), it will ask you to pick the folder.
 
-![Select your workspace folder for Front Matter](/releases/v5.0.0/workspace-folder.png)
+![Select your workspace folder for Front Matter][08]
 
 Once you selected the folder, it will create the `frontmatter.json` file and reload the workspace.
 
@@ -110,19 +110,32 @@ space? 🤓
 
 By default, you'll see the following support links:
 
-![Support links shown by default](/releases/v6.0.0/support-links.png)
+![Support links shown by default][09]
 
 When you log in via GitHub, you'll see the following:
 
-![Hidden support links](/releases/v6.0.0/support-links-hidden.png)
+![Hidden support links][10]
 
 Simply start by clicking on the **Accounts** button, and select **Sign in with GitHub to use Front
 Matter** or launch the same flow by using the `Front Matter: Authenticate` command.
 
-![Sign in with GitHub for Front Matter](/releases/v6.0.0/signin-github.png)
+![Sign in with GitHub for Front Matter][11]
 
 Follow the proposed steps from Visual Studio Code.
 
 ## Enjoy using Front Matter
 
 <iframe src="https://player.vimeo.com/video/630150787?h=9988cff4f0&amp;title=0&amp;byline=0&amp;portrait=0&amp;speed=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=56727" width="100%" height="450" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen title="Front Matter - Installation"></iframe>
+
+<!-- Link References -->
+[01]: https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter
+[02]: https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter-beta
+[03]: https://beta.frontmatter.codes
+[04]: /releases/v7.2.0/welcome-screen-7.2.0.png
+[05]: /releases/v7.2.0/content-list.png
+[06]: /assets/register-folder.png
+[07]: /docs/settings#frontmatter.content.pagefolders
+[08]: /releases/v5.0.0/workspace-folder.png
+[09]: /releases/v6.0.0/support-links.png
+[10]: /releases/v6.0.0/support-links-hidden.png
+[11]: /releases/v6.0.0/signin-github.png

--- a/content/docs/git-integration.md
+++ b/content/docs/git-integration.md
@@ -9,14 +9,16 @@ weight: 450
 
 # GIT Integration
 
-If you are using git to manage your content, Front Matter can be used to sync your changes from and to your git repository.
+If you are using git to manage your content, Front Matter can be used to sync your changes from and
+to your git repository.
 
 ![Sync your changes with GIT](/releases/v8.1.0/git-integration.png)
 
 ## Enable GIT integration
 
-To enable this feature, you will need to set the `frontMatter.git.enabled` setting to `true`. 
+To enable this feature, you will need to set the `frontMatter.git.enabled` setting to `true`.
 
 ## Change the commit message
 
-The commit message can be customized via the `frontMatter.git.commitMessage` setting (default is `Synced by Front Matter`).
+The commit message can be customized via the `frontMatter.git.commitMessage` setting (default is
+`Synced by Front Matter`).

--- a/content/docs/git-integration.md
+++ b/content/docs/git-integration.md
@@ -12,7 +12,7 @@ weight: 450
 If you are using git to manage your content, Front Matter can be used to sync your changes from and
 to your git repository.
 
-![Sync your changes with GIT](/releases/v8.1.0/git-integration.png)
+![Sync your changes with GIT][01]
 
 ## Enable GIT integration
 
@@ -22,3 +22,6 @@ To enable this feature, you will need to set the `frontMatter.git.enabled` setti
 
 The commit message can be customized via the `frontMatter.git.commitMessage` setting (default is
 `Synced by Front Matter`).
+
+<!-- Link References -->
+[01]: /releases/v8.1.0/git-integration.png

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -21,7 +21,7 @@ a full-blown Content Management System (CMS)
 The extension brings CMS capabilities straight to Visual Studio Code. For example, you can keep a
 list of the used tags, categories, create content, and so much more.
 
-![Welcome screen to configure your website](/releases/v7.2.0/welcome-screen-7.2.0.png)
+![Welcome screen to configure your website][01]
 
 Our main extension features are:
 
@@ -32,15 +32,14 @@ Our main extension features are:
 - Support for custom actions/scripts
 - and many more
 
-![Site preview](https://res.cloudinary.com/estruyf/image/upload/w_1256/v1631871148/frontmatter/preview-3.2.0.png)
+![Site preview][02]
 
 ## Why Front Matter?
 
-Initially, the Front Matter extension was created when
-[Elio Struyf](https://twitter.com/eliostruyf) migrated from WordPress to Hugo (Static web site
-Generator). To make content management more straightforward, he began to develop the Front Matter
-extension and developed more options regularly, until eventually, it became a headless CMS that runs
-on Visual Studio Code.
+Initially, the Front Matter extension was created when [Elio Struyf][03] migrated from WordPress to
+Hugo (Static web site Generator). To make content management more straightforward, he began to
+develop the Front Matter extension and developed more options regularly, until eventually, it became
+a headless CMS that runs on Visual Studio Code.
 
 ## Advantages
 
@@ -68,4 +67,10 @@ scripts will display as actions in the Front Matter panel and take your content 
 the next level.
 
 > **Example**:
-> [Generate open graph preview image in Code with Front Matter](https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/)
+> [Generate open graph preview image in Code with Front Matter][04]
+
+<!-- Link References -->
+[01]: /releases/v7.2.0/welcome-screen-7.2.0.png
+[02]: https://res.cloudinary.com/estruyf/image/upload/w_1256/v1631871148/frontmatter/preview-3.2.0.png
+[03]: https://twitter.com/eliostruyf
+[04]: https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -13,15 +13,20 @@ weight: 1
 
 ## Overview
 
-Front Matter is an integral Visual Studio Code extension that simplifies operating and managing your markdown articles. We created the extension to support several static-site generators and frameworks parallel to Hugo, Jekyll, Hexo, NextJs, Gatsby, and more which provides you the power and control of a full-blown Content Management System (CMS)
+Front Matter is an integral Visual Studio Code extension that simplifies operating and managing your
+markdown articles. We created the extension to support several static-site generators and frameworks
+parallel to Hugo, Jekyll, Hexo, NextJs, Gatsby, and more which provides you the power and control of
+a full-blown Content Management System (CMS)
 
-The extension brings CMS capabilities straight to Visual Studio Code. For example, you can keep a list of the used tags, categories, create content, and so much more.
+The extension brings CMS capabilities straight to Visual Studio Code. For example, you can keep a
+list of the used tags, categories, create content, and so much more.
 
 ![Welcome screen to configure your website](/releases/v7.2.0/welcome-screen-7.2.0.png)
 
 Our main extension features are:
 
-- Page dashboard in which you can get an overview of all of your markdown pages. You can use it to search, filter, type your contents.
+- Page dashboard in which you can get an overview of all of your markdown pages. You can use it to
+  search, filter, type your contents.
 - Site preview within Visual Studio Code
 - SEO checks for title, description, and keywords
 - Support for custom actions/scripts
@@ -31,7 +36,11 @@ Our main extension features are:
 
 ## Why Front Matter?
 
-Initially, the Front Matter extension was created when [Elio Struyf](https://twitter.com/eliostruyf) migrated from WordPress to Hugo (Static web site Generator). To make content management more straightforward, he began to develop the Front Matter extension and developed more options regularly, until eventually, it became a headless CMS that runs on Visual Studio Code.
+Initially, the Front Matter extension was created when
+[Elio Struyf](https://twitter.com/eliostruyf) migrated from WordPress to Hugo (Static web site
+Generator). To make content management more straightforward, he began to develop the Front Matter
+extension and developed more options regularly, until eventually, it became a headless CMS that runs
+on Visual Studio Code.
 
 ## Advantages
 
@@ -39,18 +48,24 @@ We believe that Front Matter gives you the subsequent advantages:
 
 ### Speed
 
-It simply runs on your machine. There are no servers/websites/APIs involved in the process. Nothing can beat this.
+It simply runs on your machine. There are no servers/websites/APIs involved in the process. Nothing
+can beat this.
 
 ### Use it within Visual Studio Code
 
-Don't jump from tool to tool. Use the tool that you like the most: of course, that's Visual Studio Code.
+Don't jump from tool to tool. Use the tool that you like the most: of course, that's Visual Studio
+Code.
 
 ### Customizable
 
-Almost all of the Front Matter features are customizable in its settings. These settings ensure that you can tweak Front Matter to your needs.
+Almost all of the Front Matter features are customizable in its settings. These settings ensure that
+you can tweak Front Matter to your needs.
 
 ### Extensibility
 
-We recognize that each website is different. That is why you can upload your custom scripts. These scripts will display as actions in the Front Matter panel and take your content material control to the next level. 
+We recognize that each website is different. That is why you can upload your custom scripts. These
+scripts will display as actions in the Front Matter panel and take your content material control to
+the next level.
 
-> **Example**: [Generate open graph preview image in Code with Front Matter](https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/)
+> **Example**:
+> [Generate open graph preview image in Code with Front Matter](https://www.eliostruyf.com/generate-open-graph-preview-image-code-front-matter/)

--- a/content/docs/markdown.md
+++ b/content/docs/markdown.md
@@ -23,7 +23,7 @@ helpful, what you see is what you get (WYSIWYG), controls while working in a Mar
 
 All the controls can be found on the top right of the opened file title bar.
 
-![WYSIWYG controls](/releases/v5.7.0/wysiwyg_controls.png)
+![WYSIWYG controls][01]
 
 Currently supported are:
 
@@ -48,38 +48,38 @@ controls will disappear.
 When you click on the headings in the WYSIWYG controls, you will be asked which level of heading you
 want to insert.
 
-![WYSIWYG headings](/releases/v5.7.0/wysiwyg_headings.png)
+![WYSIWYG headings][02]
 
 ### Other WYSIWYG options
 
 When you click on the elipsis icon in the WYSIWYG controls, you will be asked which of the advanced
 markup you want to insert.
 
-![WYSIWYG options](/releases/v5.7.0/wysiwyg_options.png)
+![WYSIWYG options][03]
 
 ## Insert images
 
 Inserting images was never easier with the `insert image into article` command, which can also be
 triggered with the image icon in the editor title bar (Markdown files only).
 
-![Insert images](/releases/v4_0_0/insert-images.gif)
+![Insert images][04]
 
 > **Info**: You can also use media snippets to insert your images. More information can be found in
-> the [Media Snippets](/docs/snippets#media-snippets) section.
+> the [Media Snippets][05] section.
 
 ## Front matter folding
 
 If you want to focus on the content of your page, you have the ability to fold the Front Matter
 section of your page.
 
-![Folding range](/assets/folding.png)
+![Folding range][06]
 
 ## Front matter highlighting
 
 The extension will automatically highlight the front matter of you document to create a visual
 difference between metadata and content.
 
-![Highlighting](/assets/fm-highlight.png)
+![Highlighting][07]
 
 > **Info**: If you do not want this feature, you can disable it in the extension settings ->
 > `Highlight Front Matter` or by setting the `frontMatter.content.fmHighlight` setting to `false`.
@@ -106,4 +106,14 @@ hidden and the Front Matter panel needs to be used to edit the metadata of your 
 
 ### Result
 
-![Hide front matter](/releases/v8.1.0/hide-fm.png)
+![Hide front matter][08]
+
+<!-- Link References -->
+[01]: /releases/v5.7.0/wysiwyg_controls.png
+[02]: /releases/v5.7.0/wysiwyg_headings.png
+[03]: /releases/v5.7.0/wysiwyg_options.png
+[04]: /releases/v4_0_0/insert-images.gif
+[05]: /docs/snippets#media-snippets
+[06]: /assets/folding.png
+[07]: /assets/fm-highlight.png
+[08]: /releases/v8.1.0/hide-fm.png

--- a/content/docs/markdown.md
+++ b/content/docs/markdown.md
@@ -11,11 +11,15 @@ weight: 800
 
 ## Overview
 
-The Front Matter extension tries to make it easy to manage your Markdown pages/content. Within a Markdown page, we allow you to fold the file's Front Matter to be less distracting when writing. Also, do we highlight the Front Matter content to create a visual difference between content and metadata.
+The Front Matter extension tries to make it easy to manage your Markdown pages/content. Within a
+Markdown page, we allow you to fold the file's Front Matter to be less distracting when writing.
+Also, do we highlight the Front Matter content to create a visual difference between content and
+metadata.
 
 ## WYSIWYG
 
-To help out content editors write their content in Markdown. Front Matter provides a couple of helpful, what you see is what you get (WYSIWYG), controls while working in a Markdown file.
+To help out content editors write their content in Markdown. Front Matter provides a couple of
+helpful, what you see is what you get (WYSIWYG), controls while working in a Markdown file.
 
 All the controls can be found on the top right of the opened file title bar.
 
@@ -35,59 +39,71 @@ Currently supported are:
 - Unordered list
 - Task list
 
-If you want, you can disable these controls with the following setting `frontMatter.content.wysiwyg`. By default, this is set to `true`. When changed to `false`, these controls will disappear.
+If you want, you can disable these controls with the following setting
+`frontMatter.content.wysiwyg`. By default, this is set to `true`. When changed to `false`, these
+controls will disappear.
 
 ### Inserting headings
 
-When you click on the headings in the WYSIWYG controls, you will be asked which level of heading you want to insert.
+When you click on the headings in the WYSIWYG controls, you will be asked which level of heading you
+want to insert.
 
 ![WYSIWYG headings](/releases/v5.7.0/wysiwyg_headings.png)
 
 ### Other WYSIWYG options
 
-When you click on the elipsis icon in the WYSIWYG controls, you will be asked which of the advanced markup you want to insert.
+When you click on the elipsis icon in the WYSIWYG controls, you will be asked which of the advanced
+markup you want to insert.
 
 ![WYSIWYG options](/releases/v5.7.0/wysiwyg_options.png)
 
 ## Insert images
 
-Inserting images was never easier with the `insert image into article` command, which can also be triggered with the image icon in the editor title bar (Markdown files only).
+Inserting images was never easier with the `insert image into article` command, which can also be
+triggered with the image icon in the editor title bar (Markdown files only).
 
 ![Insert images](/releases/v4_0_0/insert-images.gif)
 
-> **Info**: You can also use media snippets to insert your images. More information can be found in the [Media Snippets](/docs/snippets#media-snippets) section.
+> **Info**: You can also use media snippets to insert your images. More information can be found in
+> the [Media Snippets](/docs/snippets#media-snippets) section.
 
 ## Front matter folding
 
-If you want to focus on the content of your page, you have the ability to fold the Front Matter section of your page.
+If you want to focus on the content of your page, you have the ability to fold the Front Matter
+section of your page.
 
 ![Folding range](/assets/folding.png)
 
 ## Front matter highlighting
 
-The extension will automatically highlight the front matter of you document to create a visual difference between metadata and content.
+The extension will automatically highlight the front matter of you document to create a visual
+difference between metadata and content.
 
 ![Highlighting](/assets/fm-highlight.png)
 
-> **Info**: If you do not want this feature, you can disable it in the extension settings -> `Highlight Front Matter` or by setting the `frontMatter.content.fmHighlight` setting to `false`.
+> **Info**: If you do not want this feature, you can disable it in the extension settings ->
+> `Highlight Front Matter` or by setting the `frontMatter.content.fmHighlight` setting to `false`.
 
 ## Hiding front matter
 
-Hiding the front matter in the editing experience can be done by the `frontMatter.content.hideFm` setting. By default, this is set to `false`. When changed to `true`, the front matter will be hidden in the editor.
+Hiding the front matter in the editing experience can be done by the `frontMatter.content.hideFm`
+setting. By default, this is set to `false`. When changed to `true`, the front matter will be hidden
+in the editor.
 
-In combination with this setting, you can also set a message to highlight that the front matter is hidden and the Front Matter panel needs to be used to edit the metadata of your page.
+In combination with this setting, you can also set a message to highlight that the front matter is
+hidden and the Front Matter panel needs to be used to edit the metadata of your page.
 
 ### Example
 
+<!-- markdownlint-disable MD013 -->
 ```json
 {
   "frontMatter.content.hideFm": true,
   "frontMatter.content.hideFmMessage":"Use the editor panel to make front matter changes"
 }
 ```
+<!-- markdownlint-enable MD013 -->
 
 ### Result
 
 ![Hide front matter](/releases/v8.1.0/hide-fm.png)
-
-

--- a/content/docs/panel.md
+++ b/content/docs/panel.md
@@ -25,13 +25,13 @@ slug optimization, updating the date, and publish/drafting the article.
 Once you installed the extension, you will notice a Front Matter icon on the activity bar (by
 default on the left side). Clicking this icon will open the Front Matter panel.
 
-![Activity bar action](/assets/activitybar-action.png)
+![Activity bar action][01]
 
 ## Global settings
 
 In this section of the panel, you can modify a couple of the useful settings to have close to hand.
 
-![Global settings](/releases/v6.0.0/local-server.png)
+![Global settings][02]
 
 <!-- markdownlint-disable MD028 -->
 > **Info**: The global settings section will also be shown when you have the panel open on other
@@ -53,7 +53,7 @@ Supports the following:
 - Keyword validation on title, description, slug, and content
 - More content details
 
-![SEO](/releases/v5.3.0/seo-status.png)
+![SEO][03]
 
 ### Settings
 
@@ -84,10 +84,10 @@ section, we provide you the most used/requested actions like:
 - Setting the modified date
 - Publish or revert to draft
 
-![Actions](/releases/v6.0.0/local-server-start.png)
+![Actions][04]
 
 > **Important**: You are able to add your own actions, more information about this you can read in
-> our [custom actions](/docs/custom-actions) section.
+> our [custom actions][05] section.
 
 > **Info**: In version `3.2.0` a couple of actions were moved to the metadata section like changing
 > the draft state and date time properties.
@@ -107,10 +107,10 @@ The following settings are related to these actions:
 In the metadata section, you can manage the front matter of your Markdown file. This section is
 fully customizable to your needs with our `content type` support.
 
-![Metadata section](/assets/metadata.png)
+![Metadata section][06]
 
 > **Info**: More information about content creation/content types/fields can be read at
-> [content creation section](/docs/content-creation).
+> [content creation section][07].
 
 The tags and categories inputs allow you to insert known and unknown tags/categories. When an
 unknown tag/category gets added, it will show a `+` sign that allows you to add it to your
@@ -121,7 +121,7 @@ configuration so that it will appear in the known tags/categories next time.
 When Front Matter notices a difference between your content and the content type defined, it will
 show you a list of actions.
 
-![Content type actions](/releases/v7.2.0/content-type-actions.png)
+![Content type actions][08]
 
 - **Create content type**: This will generate a new content type based on the fields in your front
   matter.
@@ -140,10 +140,10 @@ show you a list of actions.
 Navigate quickly to a recently modified file. In the recently modified section, the latest 10
 modified files get shown.
 
-![Recently modified](/assets/recent-files.png)
+![Recently modified][09]
 
 > **Important**: In order to use this functionality, a registered content folder needs to be
-> present. More information in our [getting started](/docs/getting-started) section.
+> present. More information in our [getting started][10] section.
 
 > **Info**: The recently modified section will also be shown when you have the panel open on other
 > types of files.
@@ -153,7 +153,7 @@ modified files get shown.
 This section provides a couple of other useful actions, like opening the current project in your
 explorer/finder.
 
-![Other actions](/assets/other-actions.png)
+![Other actions][11]
 
 > **Info**: The `writing settings enabled / enable write settings` action allows you to make
 > Markdown specific changes to optimize the writing of your articles. It will change settings like
@@ -213,8 +213,23 @@ Here is an example of a custom view mode:
 Once you created a new view mode, you can change between the default and custom ones. You find the
 mode switch in the panel:
 
-![Switch view mode](/releases/v7.1.0/panel-mode-switch.png)
+![Switch view mode][12]
 
 Or in the status bar:
 
-![Status bar mode switch](/releases/v7.1.0/status-bar-mode-switch.png)
+![Status bar mode switch][13]
+
+<!-- Link References -->
+[01]: /assets/activitybar-action.png
+[02]: /releases/v6.0.0/local-server.png
+[03]: /releases/v5.3.0/seo-status.png
+[04]: /releases/v6.0.0/local-server-start.png
+[05]: /docs/custom-actions
+[06]: /assets/metadata.png
+[07]: /docs/content-creation
+[08]: /releases/v7.2.0/content-type-actions.png
+[09]: /assets/recent-files.png
+[10]: /docs/getting-started
+[11]: /assets/other-actions.png
+[12]: /releases/v7.1.0/panel-mode-switch.png
+[13]: /releases/v7.1.0/status-bar-mode-switch.png

--- a/content/docs/panel.md
+++ b/content/docs/panel.md
@@ -11,15 +11,19 @@ weight: 400
 
 ## Overview
 
-The Front Matter panel allows you to perform most of the extension actions by just a click on the button, and it shows the SEO statuses of your title, description, and more.
+The Front Matter panel allows you to perform most of the extension actions by just a click on the
+button, and it shows the SEO statuses of your title, description, and more.
 
-> **Info**: Initially, this panel was created to add tags and categories easily to your articles, as currently, VS Code multi-select is not optimal to use when having a lot of tags/categories.
+> **Info**: Initially, this panel was created to add tags and categories easily to your articles, as
+> currently, VS Code multi-select is not optimal to use when having a lot of tags/categories.
 
-To leverage most of the capabilities of the extension. SEO information and everyday actions like slug optimization, updating the date, and publish/drafting the article.
+To leverage most of the capabilities of the extension. SEO information and everyday actions like
+slug optimization, updating the date, and publish/drafting the article.
 
 ## Using the panel
 
-Once you installed the extension, you will notice a Front Matter icon on the activity bar (by default on the left side). Clicking this icon will open the Front Matter panel.
+Once you installed the extension, you will notice a Front Matter icon on the activity bar (by
+default on the left side). Clicking this icon will open the Front Matter panel.
 
 ![Activity bar action](/assets/activitybar-action.png)
 
@@ -29,13 +33,18 @@ In this section of the panel, you can modify a couple of the useful settings to 
 
 ![Global settings](/releases/v6.0.0/local-server.png)
 
-> **Info**: The global settings section will also be shown when you have the panel open on other types of files.
+<!-- markdownlint-disable MD028 -->
+> **Info**: The global settings section will also be shown when you have the panel open on other
+> types of files.
 
-> **Local server command**: If you already defined your framework or SSG via the `frontMatter.framework.id` setting, we provide a default start command for you. You can override this by providing your own start command.
+> **Local server command**: If you already defined your framework or SSG via the
+> `frontMatter.framework.id` setting, we provide a default start command for you. You can override
+> this by providing your own start command.
 
 ## SEO status
 
-Search Engine Optimization or simply SEO is very important to any site. The extension shows you more information about how well your article is written.
+Search Engine Optimization or simply SEO is very important to any site. The extension shows you more
+information about how well your article is written.
 
 Supports the following:
 
@@ -48,19 +57,27 @@ Supports the following:
 
 ### Settings
 
-In case you want to change the SEO settings, you can use the following settings: 
+In case you want to change the SEO settings, you can use the following settings:
 
-- `frontMatter.taxonomy.seoSlugLength`: Specifies the optimal title length for SEO (set to `-1` to turn it off).
-- `frontMatter.taxonomy.seoTitleLength`: Specifies the optimal title length for SEO (set to `-1` to turn it off).
-- `frontMatter.taxonomy.seoDescriptionLength`: Specifies the optimal description length for SEO (set to `-1` to turn it off).
-- `frontMatter.taxonomy.seoContentLengh`: Specifies the optimal minimum length for your articles. Between 1,760 words – 2,400 is the absolute ideal article length for SEO in 2021. (set to `-1` to turn it off).
-- `frontMatter.taxonomy.seoDescriptionField`: Specifies the name of the SEO description field for your page. Default is 'description'.
+- `frontMatter.taxonomy.seoSlugLength`: Specifies the optimal title length for SEO (set to `-1` to
+  turn it off).
+- `frontMatter.taxonomy.seoTitleLength`: Specifies the optimal title length for SEO (set to `-1` to
+  turn it off).
+- `frontMatter.taxonomy.seoDescriptionLength`: Specifies the optimal description length for SEO (set
+  to `-1` to turn it off).
+- `frontMatter.taxonomy.seoContentLengh`: Specifies the optimal minimum length for your articles.
+  Between 1,760 words – 2,400 is the absolute ideal article length for SEO in 2021. (set to `-1` to
+  turn it off).
+- `frontMatter.taxonomy.seoDescriptionField`: Specifies the name of the SEO description field for
+  your page. Default is 'description'.
 
-To discover your internal links, you can specify your base URL with the `frontMatter.site.baseURL` setting.
+To discover your internal links, you can specify your base URL with the `frontMatter.site.baseURL`
+setting.
 
 ## Actions
 
-When writing articles, there are always a couple of actions you need/want to perform. In this section, we provide you the most used/requested actions like:
+When writing articles, there are always a couple of actions you need/want to perform. In this
+section, we provide you the most used/requested actions like:
 
 - Optimizing the slug
 - Setting the publishing date
@@ -69,85 +86,106 @@ When writing articles, there are always a couple of actions you need/want to per
 
 ![Actions](/releases/v6.0.0/local-server-start.png)
 
-> **Important**: You are able to add your own actions, more information about this you can read in our [custom actions](/docs/custom-actions) section.
+> **Important**: You are able to add your own actions, more information about this you can read in
+> our [custom actions](/docs/custom-actions) section.
 
-> **Info**: In version `3.2.0` a couple of actions were moved to the metadata section like changing the draft state and date time properties.
+> **Info**: In version `3.2.0` a couple of actions were moved to the metadata section like changing
+> the draft state and date time properties.
 
 ### Settings
 
 The following settings are related to these actions:
 
-- `frontMatter.preview.host`: Specify the host URL (example: http://localhost:1313) to be used when opening the preview.
+- `frontMatter.preview.host`: Specify the host URL (example: `http://localhost:1313`) to be used
+  when opening the preview.
 - `frontMatter.taxonomy.slugPrefix`: Specify a prefix for the slug.
 - `frontMatter.taxonomy.slugSuffix`: Specify a suffix for the slug.
 - `frontMatter.taxonomy.alignFilename`: Align the filename with the new slug when it gets generated.
 
 ## Metadata
 
-In the metadata section, you can manage the front matter of your Markdown file. This section is fully customizable to your needs with our `content type` support.
+In the metadata section, you can manage the front matter of your Markdown file. This section is
+fully customizable to your needs with our `content type` support.
 
 ![Metadata section](/assets/metadata.png)
 
-> **Info**: More information about content creation/content types/fields can be read at [content creation section](/docs/content-creation).
+> **Info**: More information about content creation/content types/fields can be read at
+> [content creation section](/docs/content-creation).
 
-The tags and categories inputs allow you to insert known and unknown tags/categories. When an unknown tag/category gets added, it will show a `+` sign that allows you to add it to your configuration so that it will appear in the known tags/categories next time.
+The tags and categories inputs allow you to insert known and unknown tags/categories. When an
+unknown tag/category gets added, it will show a `+` sign that allows you to add it to your
+configuration so that it will appear in the known tags/categories next time.
 
 ### Content type actions
 
-When Front Matter notices a difference between your content and the content type defined, it will show you a list of actions.
+When Front Matter notices a difference between your content and the content type defined, it will
+show you a list of actions.
 
 ![Content type actions](/releases/v7.2.0/content-type-actions.png)
 
-- **Create content type**: This will generate a new content type based on the fields in your front matter.
+- **Create content type**: This will generate a new content type based on the fields in your front
+  matter.
 - **Update missing fields**: Adds the fields that are missing in your content type.
-- **Set content type**: Allows you to set a content type (which you already defined) for your content.
+- **Set content type**: Allows you to set a content type (which you already defined) for your
+  content.
 
 ### Settings
 
-- `frontMatter.panel.freeform`: Specifies if you want to allow yourself from entering unknown tags/categories in the tag picker (when enabled, you will have the option to store them afterwards). Default: `true`.
-- `frontMatter.taxonomy.frontMatterType`: Specify which Front Matter language you want to use. The extension supports `YAML` (default), `TOML`, and `JSON`.
-## Recently modified
+- `frontMatter.panel.freeform`: Specifies if you want to allow yourself from entering unknown
+  tags/categories in the tag picker (when enabled, you will have the option to store them
+  afterwards). Default: `true`.
+- `frontMatter.taxonomy.frontMatterType`: Specify which Front Matter language you want to use. The
+  extension supports `YAML` (default), `TOML`, and `JSON`. ## Recently modified
 
-Navigate quickly to a recently modified file. In the recently modified section, the latest 10 modified files get shown. 
+Navigate quickly to a recently modified file. In the recently modified section, the latest 10
+modified files get shown.
 
 ![Recently modified](/assets/recent-files.png)
 
-> **Important**: In order to use this functionality, a registered content folder needs to be present. More information in our [getting started](/docs/getting-started) section.
+> **Important**: In order to use this functionality, a registered content folder needs to be
+> present. More information in our [getting started](/docs/getting-started) section.
 
-> **Info**: The recently modified section will also be shown when you have the panel open on other types of files.
+> **Info**: The recently modified section will also be shown when you have the panel open on other
+> types of files.
 
 ## Other actions
 
-This section provides a couple of other useful actions, like opening the current project in your explorer/finder. 
+This section provides a couple of other useful actions, like opening the current project in your
+explorer/finder.
 
 ![Other actions](/assets/other-actions.png)
 
-> **Info**: The `writing settings enabled / enable write settings` action allows you to make Markdown specific changes to optimize the writing of your articles. It will change settings like the `fontSize`, `lineHeight`, `wordWrap`, `lineNumbers` and more.
+> **Info**: The `writing settings enabled / enable write settings` action allows you to make
+> Markdown specific changes to optimize the writing of your articles. It will change settings like
+> the `fontSize`, `lineHeight`, `wordWrap`, `lineNumbers` and more.
 
-> **Info**: The other actions section will also be shown when you have the panel open on other types of files.
-
+> **Info**: The other actions section will also be shown when you have the panel open on other types
+> of files.
 
 ## View modes
 
-By default, Front Matter will show all its potential and functionalities to the end-user. As you do not always require all functionality, Front Matter allows you to create view modes. 
+By default, Front Matter will show all its potential and functionalities to the end-user. As you do
+not always require all functionality, Front Matter allows you to create view modes.
 
 You can define what functionality you want to show and use in a view mode.
 
-The creation of a view mode can be done in the `frontMatter.global.modes` setting and the by default activated mode, can be set in the `frontMatter.global.activeMode` setting.
+The creation of a view mode can be done in the `frontMatter.global.modes` setting and the by default
+activated mode, can be set in the `frontMatter.global.activeMode` setting.
 
 You define a mode with an `id` and a set of features. The allowed features are the following:
 
-**Panel**
+### Panel
 
 - `panel.globalSettings`: Show the global settings section.
 - `panel.seo`: Show the SEO status section.
 - `panel.actions`: Show the actions section.
 - `panel.metadata`: Show the metadata section.
-- `panel.contentType`: Show the content type create, update, and set actions underneath the metadata panel section.
+- `panel.contentType`: Show the content type create, update, and set actions underneath the metadata
+  panel section.
 - `panel.recentlyModified`: Show the recently modified files section.
 - `panel.otherActions`: Show the other actions section.
 
-**Dashboards**
+### Dashboards
 
 - `dashboard.snippets.view`: Show the snippets dashboard.
 - `dashboard.snippets.manage`: Show the snippets management actions.
@@ -172,7 +210,8 @@ Here is an example of a custom view mode:
 ]
 ```
 
-Once you created a new view mode, you can change between the default and custom ones. You find the mode switch in the panel:
+Once you created a new view mode, you can change between the default and custom ones. You find the
+mode switch in the panel:
 
 ![Switch view mode](/releases/v7.1.0/panel-mode-switch.png)
 

--- a/content/docs/settings.md
+++ b/content/docs/settings.md
@@ -11,48 +11,60 @@ weight: 1100
 
 ## Overview
 
-Most of Front Matter is configurable to your needs. In this part of the documentation all settings are explained.
+Most of Front Matter is configurable to your needs. In this part of the documentation all settings
+are explained.
 
 ## Team settings and local settings
 
-Since version 4 of Front Matter, Team settings got introduced. Teams settings allow you to have all settings on the project/solution level. You will be able to override them on user/local level (`.vscode/settings.json`).
+Since version 4 of Front Matter, Team settings got introduced. Teams settings allow you to have all
+settings on the project/solution level. You will be able to override them on user/local level
+(`.vscode/settings.json`).
 
-The purpose of team settings is to share the global configuration of your CMS configuration. This way, your whole team can use the same tags/categories but apply their changes locally.
+The purpose of team settings is to share the global configuration of your CMS configuration. This
+way, your whole team can use the same tags/categories but apply their changes locally.
 
-As you do not typically share your `.vscode/settings.json` configuration, we went for a `frontmatter.json` file on the root of your project/solution. The settings you provide in this JSON file are the same as you can configure on a local level. This allows you to easily copy, move settings from team to local level and vice versa.
+As you do not typically share your `.vscode/settings.json` configuration, we went for a
+`frontmatter.json` file on the root of your project/solution. The settings you provide in this JSON
+file are the same as you can configure on a local level. This allows you to easily copy, move
+settings from team to local level and vice versa.
 
 ## Migrate local settings to team settings
 
-To allow you to easily migrate already defined settings, you can run the `Promote settings from local to team level` command. The very first time, it will also ask you if there are settings that can be promoted.
+To allow you to easily migrate already defined settings, you can run the
+`Promote settings from local to team level` command. The very first time, it will also ask you if
+there are settings that can be promoted.
 
 ![On startup, Front Matter checks if settings can be promoted](/releases/v5.0.0/ask-to-promote-settings.png)
 
 ## Splitting your settings in multiple files
 
-Some of the Front Matter settings can be split in multiple files to make management of these easier. For example, in case you are using multiple content-types for your site, you can now split each content-type to its own file. This allows you to easily manage the settings for each content-type.
+Some of the Front Matter settings can be split in multiple files to make management of these easier.
+For example, in case you are using multiple content-types for your site, you can now split each
+content-type to its own file. This allows you to easily manage the settings for each content-type.
 
 ### Supported settings to split
 
 The following settings are supported to be split in multiple files:
 
-| Setting name | Folder path | Information | JSON Schema |
-| --- | --- | --- | --- |
-| `frontMatter.content.pageFolders` |`./frontmatter/config/content/pagefolders/` | | `https://beta.frontmatter.codes/config/content.pagefolders.schema.json` | 
-| `frontMatter.content.placeholders` | `./frontmatter/config/content/placeholders/` | | `https://beta.frontmatter.codes/config/content.placeholders.schema.json` |
-| `frontMatter.content.snippets` | `./frontmatter/config/content/snippets/` | The file name will be used as the ID/title of the snippet. | `https://beta.frontmatter.codes/config/content.snippets.schema.json` |
-| `frontMatter.custom.scripts` | `./frontmatter/config/custom/scripts/` | | `https://beta.frontmatter.codes/config/custom.scripts.schema.json` |
-| `frontMatter.data.files` | `./frontmatter/config/data/files/` | | `https://beta.frontmatter.codes/config/data.files.schema.json` |
-| `frontMatter.data.folders` | `./frontmatter/config/data/folders/` | | `https://beta.frontmatter.codes/config/data.folders.schema.json` |
-| `frontMatter.data.types` | `./frontmatter/config/data/types/` | | `https://beta.frontmatter.codes/config/data.types.schema.json` |
-| `frontMatter.taxonomy.contentTypes` | `./frontmatter/config/taxonomy/contenttypes/` | | `https://beta.frontmatter.codes/config/taxonomy.contenttypes.schema.json` |
+| Setting name                        | Folder path                                   | Information                                                | JSON Schema                                                               |
+| ----------------------------------- | --------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `frontMatter.content.pageFolders`   | `./frontmatter/config/content/pagefolders/`   |                                                            | `https://beta.frontmatter.codes/config/content.pagefolders.schema.json`   |
+| `frontMatter.content.placeholders`  | `./frontmatter/config/content/placeholders/`  |                                                            | `https://beta.frontmatter.codes/config/content.placeholders.schema.json`  |
+| `frontMatter.content.snippets`      | `./frontmatter/config/content/snippets/`      | The file name will be used as the ID/title of the snippet. | `https://beta.frontmatter.codes/config/content.snippets.schema.json`      |
+| `frontMatter.custom.scripts`        | `./frontmatter/config/custom/scripts/`        |                                                            | `https://beta.frontmatter.codes/config/custom.scripts.schema.json`        |
+| `frontMatter.data.files`            | `./frontmatter/config/data/files/`            |                                                            | `https://beta.frontmatter.codes/config/data.files.schema.json`            |
+| `frontMatter.data.folders`          | `./frontmatter/config/data/folders/`          |                                                            | `https://beta.frontmatter.codes/config/data.folders.schema.json`          |
+| `frontMatter.data.types`            | `./frontmatter/config/data/types/`            |                                                            | `https://beta.frontmatter.codes/config/data.types.schema.json`            |
+| `frontMatter.taxonomy.contentTypes` | `./frontmatter/config/taxonomy/contenttypes/` |                                                            | `https://beta.frontmatter.codes/config/taxonomy.contenttypes.schema.json` |
 
-> **Important**: The folder path is relative to the root of your project/solution and you create the files in their corresponding folder. The file name is the same as the `id` of the setting.
+> **Important**: The folder path is relative to the root of your project/solution and you create the
+> files in their corresponding folder. The file name is the same as the `id` of the setting.
 
 ### Example of splitting a setting
 
 Example of specifying a page folder in a separate file:
 
-```
+```text
 | .frontmatter
 | - config
 | -- content
@@ -72,7 +84,11 @@ Contents of the `blog.json` file:
 
 ### Reviewing composed settings
 
-You can inspect your composed settings with the [diagnostic logging](/docs/commands#diagnostic-logging) command, which shows you the [Complete frontmatter.json config](/docs/troubleshooting#inspecting-configuration-behavior) in a virtual Markdown document. Use that output to verify that your split configuration settings are applied the way you expect.
+You can inspect your composed settings with the
+[diagnostic logging](/docs/commands#diagnostic-logging) command, which shows you the
+[Complete frontmatter.json config](/docs/troubleshooting#inspecting-configuration-behavior) in a
+virtual Markdown document. Use that output to verify that your split configuration settings are
+applied the way you expect.
 
 ## Available settings
 
@@ -99,9 +115,10 @@ Options:
 
 ### frontMatter.content.defaultSorting
 
-Specify the default sorting option for the content dashboard. You can use one of the values from the enum or define your own ID.
+Specify the default sorting option for the content dashboard. You can use one of the values from the
+enum or define your own ID.
 
-- Type: `string` 
+- Type: `string`
 - Default: `""`
 
 Options:
@@ -116,13 +133,14 @@ Options:
 
 Define the draft field you want to use to manage your content.
 
-- Type: `object` 
+- Type: `object`
   - **name**: Define the type of field
   - **type**: `boolean` or `choice`
-  - **invert**: `true` if you want to invert the value. This inversion is only applied if the field is a boolean field and can be used to change the draft to published content behaviou.
+  - **invert**: `true` if you want to invert the value. This inversion is only applied if the field
+    is a boolean field and can be used to change the draft to published content behaviou.
   - **choices**: Define the choices of the draft field `string[]`
 
-- Default: 
+- Default:
 
 ```json
 {
@@ -137,7 +155,6 @@ Specify if you want to highlight the Front Matter in the Markdown file.
 
 - Type: `boolean`
 - Default: `true`
-
 
 ### frontMatter.content.hideFm
 
@@ -157,21 +174,23 @@ Specify the message to display when the Front Matter is hidden.
 
 ### frontMatter.content.pageFolders
 
-This array of folders defines where the extension can find your content and create new content by running the create article command.
+This array of folders defines where the extension can find your content and create new content by
+running the create article command.
 
 - Type: `object[]`
 - Default: `[]`
 
 Properties:
 
-| Title | Type | Description | Default | Required / Optional |
-| --- | --- | --- | --- | --- |
-| `title` | `string` | A title for the content folder path | `""` | Optional |
-| `path` | `string` | The path to the content folder, important is to use the `[[workspace]]` placeholder | `""` | Required |
-| `excludeSubdir` | `boolean` | Exclude subdirectories from the content folder | | Optional |
-| `previewPath` | `string` | Allows you to set a prefix path for the page preview. Check the [preview path configuration](/docs/site-preview#configuration) section to learn more. |  | Optional |
+| Title           | Type      | Description                                                                                                                                           | Default | Required / Optional |
+| --------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------- |
+| `title`         | `string`  | A title for the content folder path                                                                                                                   | `""`    | Optional            |
+| `path`          | `string`  | The path to the content folder, important is to use the `[[workspace]]` placeholder                                                                   | `""`    | Required            |
+| `excludeSubdir` | `boolean` | Exclude subdirectories from the content folder                                                                                                        |         | Optional            |
+| `previewPath`   | `string`  | Allows you to set a prefix path for the page preview. Check the [preview path configuration](/docs/site-preview#configuration) section to learn more. |         | Optional            |
 
-> **Important**: `[[workspace]]` is a placeholder that the extension uses to replace the workspace path. The reason why we choose to use this, is because some do not keep the original folder name.
+> **Important**: `[[workspace]]` is a placeholder that the extension uses to replace the workspace
+> path. The reason why we choose to use this, is because some do not keep the original folder name.
 
 Sample:
 
@@ -204,11 +223,13 @@ Properties:
 - `id`: The id of the placeholder
 - `value`: The value of the placeholder
 
-> More information on how you can use it can be found here: [placeholders](/docs/content-creation/placeholders).
+> **Info**: More information on how you can use it can be found here:
+> [placeholders](/docs/content-creation/placeholders).
 
 ### frontMatter.content.publicFolder
 
-Specify the folder name where all your assets are located. For instance in Hugo this is the `static` folder.
+Specify the folder name where all your assets are located. For instance in Hugo this is the `static`
+folder.
 
 - Type: `string`
 - Default: `""`
@@ -224,7 +245,8 @@ Properties:
 
 - `title`: The title of the sorting option
 - `name`: The name of the field to sort by (needs to be present in your content its front matter)
-- `order`: The order of the sorting (ascending or descending). Option values to use: `asc` or `desc`.
+- `order`: The order of the sorting (ascending or descending). Option values to use: `asc` or
+  `desc`.
 - `type`: The type of field value. Option values to use: `string`, `date`, and `number`.
 
 Sample:
@@ -252,19 +274,21 @@ Sample:
 
 Specify the file types that you want to use in Front Matter.
 
-- Type: `array` 
+- Type: `array`
 - Default: `[md, mdx, markdown]`
 
 ### frontMatter.content.wysiwyg
 
-Specifies if you want to enable/disable the What You See, Is What You Get (WYSIWYG) markdown controls.
+Specifies if you want to enable/disable the What You See, Is What You Get (WYSIWYG) markdown
+controls.
 
 - Type: `boolean`
 - Default: `true`
 
 ### frontMatter.custom.scripts
 
-Specify the path to a Node.js script to execute. The current file path will be provided as an argument.
+Specify the path to a Node.js script to execute. The current file path will be provided as an
+argument.
 
 - Type: `object[]`
 - Default: `[]`
@@ -285,9 +309,10 @@ Sample:
 
 ### frontMatter.dashboard.content.cardTags
 
-Specify the name of the metadata field that will be used to show the tags on the content card. When empty or null, it will hide the tags from the card.
+Specify the name of the metadata field that will be used to show the tags on the content card. When
+empty or null, it will hide the tags from the card.
 
-- Type: `string` 
+- Type: `string`
 - Default: `tags`
 
 > **Info**: Check the [card tags](/docs/dashboard#card-tags) section for more information.
@@ -296,7 +321,7 @@ Specify the name of the metadata field that will be used to show the tags on the
 
 Specify if you want to enable/disable pagination for your content.
 
-- Type: `boolean` 
+- Type: `boolean`
 - Default: `true`
 
 ### frontMatter.dashboard.openOnStart
@@ -308,39 +333,44 @@ Specify if you want to open the dashboard when you start VS Code.
 
 ### frontMatter.data.files
 
-Specify the data files you want to use for your website. 
+Specify the data files you want to use for your website.
 
-- Type: `array` 
+- Type: `array`
 - Default: ``
 
-> More information on how to use it can be found in the [data files view](/docs/dashboard#data-files-view) section.
+> More information on how to use it can be found in the
+> [data files view](/docs/dashboard#data-files-view) section.
 
 ### frontMatter.data.folders
 
 Specify the data files you want to use for your website.
 
-- Type: `array` 
+- Type: `array`
 - Default: ``
 
-> More information on how to use it can be found in the [data files view](/docs/dashboard#data-files-view) section.
+> More information on how to use it can be found in the
+> [data files view](/docs/dashboard#data-files-view) section.
 
 ### frontMatter.data.types
 
 Specify the data types. These types can be used in for your data files.
 
-- Type: `array` 
+- Type: `array`
 - Default: ``
 
-> More information on how to use it can be found in the [data files view](/docs/dashboard#data-files-view) section.
+> More information on how to use it can be found in the
+> [data files view](/docs/dashboard#data-files-view) section.
 
 ### frontMatter.file.preserveCasing
 
 Specify if you want to preserve the casing of your file names from the title.
 
-- Type: `boolean` 
+- Type: `boolean`
 - Default: `false`
 
-> More information on how to use it can be found in the [preserve the casing for your file names](/docs/content-creation/additional-config#preserve-casing-of-file-names) section.
+> More information on how to use it can be found in the
+> [preserve the casing for your file names](/docs/content-creation/additional-config#preserve-casing-of-file-names)
+> section.
 
 ### frontMatter.framework.id
 
@@ -356,7 +386,6 @@ Specify if you want to use the Git actions for your website.
 - Type: `boolean`
 - Default: `false`
 
-
 ### frontMatter.git.commitMessage
 
 Specify the commit message you want to use for the sync.
@@ -370,16 +399,18 @@ Specify the activated mode of Front Matter.
 
 - Type: `string, null`
 
-> **Info**: Check the [view mode](/docs/panel#define-view-modes) documentation section for more information.
+> **Info**: Check the [view mode](/docs/panel#define-view-modes) documentation section for more
+> information.
 
 ### frontMatter.global.modes
 
 Specify the modes you want to use for Front Matter.
 
-- Type: `array` 
+- Type: `array`
 - Default: ``
 
-> **Info**: Check the [view mode](/docs/panel#define-view-modes) documentation section for more information.
+> **Info**: Check the [view mode](/docs/panel#define-view-modes) documentation section for more
+> information.
 
 ### frontMatter.global.disabledNotifications
 
@@ -401,7 +432,7 @@ Specifies which type of notifications you want to see or which you want to hide.
 
 Specify the default sorting option for the media dashboard.
 
-- Type: `string` 
+- Type: `string`
 - Default: `""`
 
 Options:
@@ -415,31 +446,36 @@ Options:
 
 Specify the mime types to support for the media files.
 
-- Type: `array` 
+- Type: `array`
 - Default: `image/*, video/*, audio/*`
 
 ### frontMatter.panel.freeform
 
-Specifies if you want to allow yourself from entering unknown tags/categories in the tag picker (when enabled, you will have the option to store them afterwards).
+Specifies if you want to allow yourself from entering unknown tags/categories in the tag picker
+(when enabled, you will have the option to store them afterwards).
 
 - Type: `boolean`
 - Default: `true`
 
 ### frontMatter.preview.host
 
-Specify the host URL (example: http://localhost:1313) to be used when opening the preview.
+Specify the host URL (example: `http://localhost:1313`) to be used when opening the preview.
 
 - Type: `string`
 - Default: `""`
 
 ### frontMatter.preview.pathName
 
-Specify the path you want to add after the host and before your slug. This can be used for instance to include the year/month like: `yyyy/MM`. The date will be generated based on the article its date field value.
+Specify the path you want to add after the host and before your slug. This can be used for instance
+to include the year/month like: `yyyy/MM`. The date will be generated based on the article its date
+field value.
 
 - Type: `string`
 - Default: `""`
 
-> **Important**: As the value will be formatted with the article's date, it will try to convert all characters you enter. In case you want to skip some characters or all of them, you need to wrap that part between two single quotes. Example: `"'blog/'yyyy/MM"` will result in: `blog/2021/08`.
+> **Important**: As the value will be formatted with the article's date, it will try to convert all
+> characters you enter. In case you want to skip some characters or all of them, you need to wrap
+> that part between two single quotes. Example: `"'blog/'yyyy/MM"` will result in: `blog/2021/08`.
 
 ### frontMatter.site.baseURL
 
@@ -471,15 +507,17 @@ Specify the fields names that Front Matter should treat as a comma-separated arr
 - Type: `string[]`
 - Default: `[]`
 
-> **Info**: As some site generators expect arrays in `YAML` to be comma-separated like Pelican. You can use this setting to define which of the front matter properties should be treated as an comma-separated array.
+> **Info**: As some site generators expect arrays in `YAML` to be comma-separated like Pelican. You
+> can use this setting to define which of the front matter properties should be treated as an
+> comma-separated array.
 
 ### frontMatter.taxonomy.contentTypes
 
-Specify the type of contents you want to use for your articles/pages/etc. Make sure the `type` is correctly set in your front matter.
+Specify the type of contents you want to use for your articles/pages/etc. Make sure the `type` is
+correctly set in your front matter.
 
-- Type: `array, null` 
+- Type: `array, null`
 - Default: check [default content type](/docs/content-creation/content-types#changing-the-default-content-type)
-
 
 ### frontMatter.taxonomy.customTaxonomy
 
@@ -503,11 +541,13 @@ Sample:
   ]
 ```
 
-> **Info**: Check the [custom taxonomy](/docs/content-creation/fields#taxonomy) section for more information.
+> **Info**: Check the [custom taxonomy](/docs/content-creation/fields#taxonomy) section for more
+> information.
 
 ### frontMatter.taxonomy.dateFormat
 
-Specify the date format for your articles. Check [date-fns formating](https://date-fns.org/v2.0.1/docs/format) for more information.
+Specify the date format for your articles. Check
+[date-fns formating](https://date-fns.org/v2.0.1/docs/format) for more information.
 
 - Type: `string`
 - Default: `iso`
@@ -519,11 +559,13 @@ Define the field groups you want to use for your block fields.
 - Type: `array[object]`
 - Default: `[]`
 
-> More information on how to use this setting can be found on the [block field](/docs/content-creation/fields#block) section of content creation. 
+> More information on how to use this setting can be found on the
+> [block field](/docs/content-creation/fields#block) section of content creation.
 
 ### frontMatter.taxonomy.frontMatterType
 
-Specify which Front Matter language you want to use. The extension supports `YAML` (default), `TOML`, and `JSON`.
+Specify which Front Matter language you want to use. The extension supports `YAML` (default),
+`TOML`, and `JSON`.
 
 - Type: `enum: YAML | TOML | JSON`
 - Default: `YAML`
@@ -537,7 +579,9 @@ Specify if arrays in front matter of the markdown files are indented.
 
 ### frontMatter.taxonomy.noPropertyValueQuotes
 
-Specify the property names of which you want to remove the quotes in the output value. Warning: only use this when you know what you are doing. If you're going to, for instance, remove the quotes from the date property, you can add the following:
+Specify the property names of which you want to remove the quotes in the output value. Warning: only
+use this when you know what you are doing. If you're going to, for instance, remove the quotes from
+the date property, you can add the following:
 
 ```json
 {
@@ -550,7 +594,8 @@ Specify the property names of which you want to remove the quotes in the output 
 
 ### frontMatter.taxonomy.seoContentLengh
 
-Specifies the optimal minimum length for your articles. Between 1,760 words – 2,400 is the absolute ideal article length for SEO in 2021. (set to `-1` to turn it off).
+Specifies the optimal minimum length for your articles. Between 1,760 words – 2,400 is the absolute
+ideal article length for SEO in 2021. (set to `-1` to turn it off).
 
 - Type: `number`
 - Default: `1760`
@@ -575,7 +620,7 @@ Specifies the optimal description length for SEO (set to `-1` to turn it off).
 
 Specifies the optimal slug length for SEO (set to `-1` to turn it off).
 
-- Type: `number` 
+- Type: `number`
 - Default: `75`
 
 ### frontMatter.taxonomy.seoTitleLength
@@ -610,7 +655,8 @@ Specifies the tags which can be used in the Front Matter.
 
 Specify if you want to disable the telemetry.
 
-> **Important**: No user data is tracked, we only use telemetry to see what is used, and what isn't. This allows us to make accurate decisions on what to add or enhance to the extension.
+> **Important**: No user data is tracked, we only use telemetry to see what is used, and what isn't.
+> This allows us to make accurate decisions on what to add or enhance to the extension.
 
 - Type: `boolean`
 - Default: `false`
@@ -629,7 +675,8 @@ Specify the folder to use for your article templates.
 - Type: `string`
 - Default: `.frontmatter/templates`
 
-> **Important**: In version 5 of Front Matter, we moved the default location from `.templates` to `.frontmatter/templates`.
+> **Important**: In version 5 of Front Matter, we moved the default location from `.templates` to
+> `.frontmatter/templates`.
 
 ### frontMatter.templates.prefix
 
@@ -637,7 +684,6 @@ Specify the prefix you want to add for your new article filenames.
 
 - Type: `string`
 - Default: `yyyy-MM-dd`
-
 
 ## Deprecated settings
 
@@ -661,12 +707,12 @@ This setting is used to define the modified date field of your articles.
 
 ### frontMatter.dashboard.mediaSnippet
 
-This setting is deprecated in version 7.3.0 and and will be removed in the next major version. Please define your media snippet in the `frontMatter.content.snippet` setting.
-
-
+This setting is deprecated in version 7.3.0 and and will be removed in the next major version.
+Please define your media snippet in the `frontMatter.content.snippet` setting.
 
 ## Removed settings
 
 ### frontMatter.content.folders
 
-This setting has been deprecated since version `3.1.0` in favour of the newly introduced `frontMatter.content.pageFolders` setting.
+This setting has been deprecated since version `3.1.0` in favour of the newly introduced
+`frontMatter.content.pageFolders` setting.

--- a/content/docs/settings.md
+++ b/content/docs/settings.md
@@ -34,7 +34,7 @@ To allow you to easily migrate already defined settings, you can run the
 `Promote settings from local to team level` command. The very first time, it will also ask you if
 there are settings that can be promoted.
 
-![On startup, Front Matter checks if settings can be promoted](/releases/v5.0.0/ask-to-promote-settings.png)
+![On startup, Front Matter checks if settings can be promoted][01]
 
 ## Splitting your settings in multiple files
 
@@ -84,11 +84,9 @@ Contents of the `blog.json` file:
 
 ### Reviewing composed settings
 
-You can inspect your composed settings with the
-[diagnostic logging](/docs/commands#diagnostic-logging) command, which shows you the
-[Complete frontmatter.json config](/docs/troubleshooting#inspecting-configuration-behavior) in a
-virtual Markdown document. Use that output to verify that your split configuration settings are
-applied the way you expect.
+You can inspect your composed settings with the [diagnostic logging][02] command, which shows you
+the [Complete frontmatter.json config][03] in a virtual Markdown document. Use that output to verify
+that your split configuration settings are applied the way you expect.
 
 ## Available settings
 
@@ -111,7 +109,7 @@ Options:
 - `md`
 - `mdx`
 
-> For more information how and when this is used, check [content creation](/docs/content-creation#before-you-start)
+> For more information how and when this is used, check [content creation][04]
 
 ### frontMatter.content.defaultSorting
 
@@ -170,7 +168,7 @@ Specify the message to display when the Front Matter is hidden.
 - Type: `string`
 - Default: `""`
 
-![Hide front matter from the content](/releases/v8.1.0/hide-fm.png)
+![Hide front matter from the content][05]
 
 ### frontMatter.content.pageFolders
 
@@ -182,12 +180,12 @@ running the create article command.
 
 Properties:
 
-| Title           | Type      | Description                                                                                                                                           | Default | Required / Optional |
-| --------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------- |
-| `title`         | `string`  | A title for the content folder path                                                                                                                   | `""`    | Optional            |
-| `path`          | `string`  | The path to the content folder, important is to use the `[[workspace]]` placeholder                                                                   | `""`    | Required            |
-| `excludeSubdir` | `boolean` | Exclude subdirectories from the content folder                                                                                                        |         | Optional            |
-| `previewPath`   | `string`  | Allows you to set a prefix path for the page preview. Check the [preview path configuration](/docs/site-preview#configuration) section to learn more. |         | Optional            |
+| Title           | Type      | Description                                                                                                             | Default | Required / Optional |
+| --------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- | ------- | ------------------- |
+| `title`         | `string`  | A title for the content folder path                                                                                     | `""`    | Optional            |
+| `path`          | `string`  | The path to the content folder, important is to use the `[[workspace]]` placeholder                                     | `""`    | Required            |
+| `excludeSubdir` | `boolean` | Exclude subdirectories from the content folder                                                                          |         | Optional            |
+| `previewPath`   | `string`  | Allows you to set a prefix path for the page preview. Check the [preview path configuration][06] section to learn more. |         | Optional            |
 
 > **Important**: `[[workspace]]` is a placeholder that the extension uses to replace the workspace
 > path. The reason why we choose to use this, is because some do not keep the original folder name.
@@ -223,8 +221,7 @@ Properties:
 - `id`: The id of the placeholder
 - `value`: The value of the placeholder
 
-> **Info**: More information on how you can use it can be found here:
-> [placeholders](/docs/content-creation/placeholders).
+> **Info**: More information on how you can use it can be found here: [placeholders][07].
 
 ### frontMatter.content.publicFolder
 
@@ -305,7 +302,7 @@ Sample:
 }
 ```
 
-> **Info**: Check the [create your own custom scripts](/docs/custom-actions) section for more information.
+> **Info**: Check the [create your own custom scripts][08] section for more information.
 
 ### frontMatter.dashboard.content.cardTags
 
@@ -315,7 +312,7 @@ empty or null, it will hide the tags from the card.
 - Type: `string`
 - Default: `tags`
 
-> **Info**: Check the [card tags](/docs/dashboard#card-tags) section for more information.
+> **Info**: Check the [card tags][09] section for more information.
 
 ### frontMatter.dashboard.content.pagination
 
@@ -339,7 +336,7 @@ Specify the data files you want to use for your website.
 - Default: ``
 
 > More information on how to use it can be found in the
-> [data files view](/docs/dashboard#data-files-view) section.
+> [data files view][10] section.
 
 ### frontMatter.data.folders
 
@@ -349,7 +346,7 @@ Specify the data files you want to use for your website.
 - Default: ``
 
 > More information on how to use it can be found in the
-> [data files view](/docs/dashboard#data-files-view) section.
+> [data files view][10] section.
 
 ### frontMatter.data.types
 
@@ -359,7 +356,7 @@ Specify the data types. These types can be used in for your data files.
 - Default: ``
 
 > More information on how to use it can be found in the
-> [data files view](/docs/dashboard#data-files-view) section.
+> [data files view][10] section.
 
 ### frontMatter.file.preserveCasing
 
@@ -368,9 +365,8 @@ Specify if you want to preserve the casing of your file names from the title.
 - Type: `boolean`
 - Default: `false`
 
-> More information on how to use it can be found in the
-> [preserve the casing for your file names](/docs/content-creation/additional-config#preserve-casing-of-file-names)
-> section.
+> **Info**: More information on how to use it can be found in the
+> [preserve the casing for your file names][11] section.
 
 ### frontMatter.framework.id
 
@@ -399,7 +395,7 @@ Specify the activated mode of Front Matter.
 
 - Type: `string, null`
 
-> **Info**: Check the [view mode](/docs/panel#define-view-modes) documentation section for more
+> **Info**: Check the [view mode][12] documentation section for more
 > information.
 
 ### frontMatter.global.modes
@@ -409,7 +405,7 @@ Specify the modes you want to use for Front Matter.
 - Type: `array`
 - Default: ``
 
-> **Info**: Check the [view mode](/docs/panel#define-view-modes) documentation section for more
+> **Info**: Check the [view mode][12] documentation section for more
 > information.
 
 ### frontMatter.global.disabledNotifications
@@ -517,7 +513,7 @@ Specify the type of contents you want to use for your articles/pages/etc. Make s
 correctly set in your front matter.
 
 - Type: `array, null`
-- Default: check [default content type](/docs/content-creation/content-types#changing-the-default-content-type)
+- Default: check [default content type][13]
 
 ### frontMatter.taxonomy.customTaxonomy
 
@@ -541,13 +537,11 @@ Sample:
   ]
 ```
 
-> **Info**: Check the [custom taxonomy](/docs/content-creation/fields#taxonomy) section for more
-> information.
+> **Info**: Check the [custom taxonomy][14] section for more information.
 
 ### frontMatter.taxonomy.dateFormat
 
-Specify the date format for your articles. Check
-[date-fns formating](https://date-fns.org/v2.0.1/docs/format) for more information.
+Specify the date format for your articles. Check [date-fns formating][15] for more information.
 
 - Type: `string`
 - Default: `iso`
@@ -559,8 +553,8 @@ Define the field groups you want to use for your block fields.
 - Type: `array[object]`
 - Default: `[]`
 
-> More information on how to use this setting can be found on the
-> [block field](/docs/content-creation/fields#block) section of content creation.
+> More information on how to use this setting can be found on the [block field][16] section of
+> content creation.
 
 ### frontMatter.taxonomy.frontMatterType
 
@@ -716,3 +710,22 @@ Please define your media snippet in the `frontMatter.content.snippet` setting.
 
 This setting has been deprecated since version `3.1.0` in favour of the newly introduced
 `frontMatter.content.pageFolders` setting.
+
+<!-- Link References -->
+[01]: /releases/v5.0.0/ask-to-promote-settings.png
+[02]: /docs/commands#diagnostic-logging
+[03]: /docs/troubleshooting#inspecting-configuration-behavior
+[04]: /docs/content-creation#before-you-start
+[05]: /releases/v8.1.0/hide-fm.png
+[06]: /docs/site-preview#configuration
+[07]: /docs/content-creation/placeholders
+[08]: /docs/custom-actions
+[09]: /docs/dashboard#card-tags
+[10]: /docs/dashboard#data-files-view
+<!-- markdownlint-disable-next-line MD053 - mistakenly marked as invalid -->
+[11]: /docs/content-creation/additional-config#preserve-casing-of-file-names
+[12]: /docs/panel#define-view-modes
+[13]: /docs/content-creation/content-types#changing-the-default-content-type
+[14]: /docs/content-creation/fields#taxonomy
+[15]: https://date-fns.org/v2.0.1/docs/format
+[16]: /docs/content-creation/fields#block

--- a/content/docs/site-preview.md
+++ b/content/docs/site-preview.md
@@ -11,29 +11,42 @@ weight: 700
 
 ## Overview
 
-The Markdown preview is not consistently delivering the same result as the one you will see on your site. The Front Matter extension provides you a way to show the actual site instead. 
+The Markdown preview is not consistently delivering the same result as the one you will see on your
+site. The Front Matter extension provides you a way to show the actual site instead.
 
 ![Site preview](/assets/site-preview.png)
 
 ## Configuration
 
-In order to use the site preview, you will first have to set the `frontMatter.preview.host` setting. You can set it via the `Global Settings` section in the Front Matter panel or in your `frontmatter.json` file. 
+In order to use the site preview, you will first have to set the `frontMatter.preview.host` setting.
+You can set it via the `Global Settings` section in the Front Matter panel or in your
+`frontmatter.json` file.
 
-For example, with Hugo, the local server spins up on `http://localhost:1313`. When you set this URL as the value of the `frontMatter.preview.host` setting. You can click on the open preview button and the site preview will be shown.
+For example, with Hugo, the local server spins up on `http://localhost:1313`. When you set this URL
+as the value of the `frontMatter.preview.host` setting. You can click on the open preview button and
+the site preview will be shown.
 
 ### Prefix or section configuration
 
-As Front Matter tries to support as many Static-Site Generators as possible, we made the choice to use settings that can be changed on various levels: global, per page folder, and per content type.
+As Front Matter tries to support as many Static-Site Generators as possible, we made the choice to
+use settings that can be changed on various levels: global, per page folder, and per content type.
 
-When you want to show the live site/page previews in Visual Studio Code, you can specify a custom preview path/prefix. For instance, if you create blog articles, and you want to prefix it with `blog/2021/11`, you can set this with the `previewPath` property.
+When you want to show the live site/page previews in Visual Studio Code, you can specify a custom
+preview path/prefix. For instance, if you create blog articles, and you want to prefix it with
+`blog/2021/11`, you can set this with the `previewPath` property.
 
-> **Important**: The value used for the preview will be formatted with the article's date. This means that the engine will try to  convert all characters you enter to a date formatted string. In case you wan to skip some characters or all of them to be converted, you need to wrap that part between **two single quotes**. Example: `"'blog/'yyyy/MM"` will result in: `blog/2021/11`.
+> **Important**: The value used for the preview will be formatted with the article's date. This
+> means that the engine will try to convert all characters you enter to a date formatted string. In
+> case you wan to skip some characters or all of them to be converted, you need to wrap that part
+> between **two single quotes**. Example: `"'blog/'yyyy/MM"` will result in: `blog/2021/11`.
 
 #### Globally
 
-On the global level, you can use the `frontMatter.preview.pathName` setting to specify the global path that you want to add after the `frontMatter.preview.host` setting value and before your slug. 
+On the global level, you can use the `frontMatter.preview.pathName` setting to specify the global
+path that you want to add after the `frontMatter.preview.host` setting value and before your slug.
 
-This setting can be used for instance to include the year/month like: `yyyy/MM`. The date will be generated based on the article its date field value.
+This setting can be used for instance to include the year/month like: `yyyy/MM`. The date will be
+generated based on the article its date field value.
 
 ```json
 {
@@ -43,7 +56,8 @@ This setting can be used for instance to include the year/month like: `yyyy/MM`.
 
 #### Page folder
 
-The `previewPath` property on the `frontMatter.content.pageFolders` setting, will override what is defined globally and can be used to specify a preview path per page folder.
+The `previewPath` property on the `frontMatter.content.pageFolders` setting, will override what is
+defined globally and can be used to specify a preview path per page folder.
 
 ```json
 {
@@ -59,7 +73,8 @@ The `previewPath` property on the `frontMatter.content.pageFolders` setting, wil
 
 #### Content type
 
-Similar to the `previewPath` on the page folder level, the `previewPath` property on the content type level will override what is defined on page folder level and globally.
+Similar to the `previewPath` on the page folder level, the `previewPath` property on the content
+type level will override what is defined on page folder level and globally.
 
 ```json
 "frontMatter.taxonomy.contentTypes": [
@@ -73,5 +88,3 @@ Similar to the `previewPath` on the page folder level, the `previewPath` propert
   }
 ]
 ```
-
-

--- a/content/docs/site-preview.md
+++ b/content/docs/site-preview.md
@@ -14,7 +14,7 @@ weight: 700
 The Markdown preview is not consistently delivering the same result as the one you will see on your
 site. The Front Matter extension provides you a way to show the actual site instead.
 
-![Site preview](/assets/site-preview.png)
+![Site preview][01]
 
 ## Configuration
 
@@ -88,3 +88,6 @@ type level will override what is defined on page folder level and globally.
   }
 ]
 ```
+
+<!-- Link References -->
+[01]: /assets/site-preview.png

--- a/content/docs/snippets/index.md
+++ b/content/docs/snippets/index.md
@@ -11,7 +11,9 @@ weight: 850
 
 ## Overview
 
-Snippets are a pre-defined chunk of code/text that can be used to insert in your content. It provides the editor an easy way to add various elements to the content that is defined for your project/website.
+Snippets are a pre-defined chunk of code/text that can be used to insert in your content. It
+provides the editor an easy way to add various elements to the content that is defined for your
+project/website.
 
 All snippets can be found on the snippets dashboard.
 
@@ -26,7 +28,8 @@ Follow the next steps in order to create a snippet:
 - Fill in the required fields;
 - Click on the **Save** button.
 
-Once you clicked on the **Save** button, the snippet is added to the `frontMatter.content.snippets` setting. All your placeholders will be automatically extracted and added to the `fields` property.
+Once you clicked on the **Save** button, the snippet is added to the `frontMatter.content.snippets`
+setting. All your placeholders will be automatically extracted and added to the `fields` property.
 
 The snippet definition contains the following fields:
 
@@ -48,9 +51,13 @@ The snippet definition contains the following fields:
 
 ## Placeholders
 
-In your snippets, you will be able to use placeholders to insert content from the Front Matter dashboard. To use a placeholder, you will need to add them via the following notation: `[[placeholder_name]]`.
+In your snippets, you will be able to use placeholders to insert content from the Front Matter
+dashboard. To use a placeholder, you will need to add them via the following notation:
+`[[placeholder_name]]`.
 
-Internally we use the `[[` as opening tags and `]]` as closing tags. These tags can be defined per snippet. In case of conflicts, you can define your own opening and closing tags on the snippet definition.
+Internally we use the `[[` as opening tags and `]]` as closing tags. These tags can be defined per
+snippet. In case of conflicts, you can define your own opening and closing tags on the snippet
+definition.
 
 **Example:**
 
@@ -62,22 +69,27 @@ Internally we use the `[[` as opening tags and `]]` as closing tags. These tags 
 
 In the above example, we the `type` and `selection` are the defined placeholders.
 
-> **Important**: All variables are HTML-escaped by default, if you want to add unescaped HTML content, you need to add an `&` before your variable name. Example: `[[&selection]]`.
+> **Important**: All variables are HTML-escaped by default, if you want to add unescaped HTML
+> content, you need to add an `&` before your variable name. Example: `[[&selection]]`.
 
 ## Fields
 
-Each placeholder defined, will have a corresponding field definition. If no field definition is defined for a placeholder, it will be shown as a input field when inserting the snippet.
+Each placeholder defined, will have a corresponding field definition. If no field definition is
+defined for a placeholder, it will be shown as a input field when inserting the snippet.
 
-The field definition is the same as the one we use for our content types (more information at [defining your own content type](/docs/content-creation/content-types#define-your-own-type)).
+The field definition is the same as the one we use for our content types (more information at
+[defining your own content type](/docs/content-creation/content-types#define-your-own-type)).
 
 At this moment, we only support the following field types:
 
 - `string`
 - `choice`
 
-To prepopulate a field, you can use the following special placeholders in the `default` property of your field:
+To prepopulate a field, you can use the following special placeholders in the `default` property of
+your field:
 
-- Standard placeholders are available like `{{year}}`, `{{month}}`, ... (see [Placeholders](/docs/content-creation/placeholders))
+- Standard placeholders are available like `{{year}}`, `{{month}}`, ... (see
+  [Placeholders](/docs/content-creation/placeholders))
 - `FM_SELECTED_TEXT`: This placeholder can be used to insert the selected text from the editor.
 
 **Example:**
@@ -118,7 +130,8 @@ To prepopulate a field, you can use the following special placeholders in the `d
 
 - Open one of your content files;
 - Select your text (optional);
-- Click on the **Insert snippet** button (or use the **Front Matter: Insert snippet into your content** command);
+- Click on the **Insert snippet** button (or use the **Front Matter: Insert snippet into your
+  content** command);
 
 ![Insert a snippet](/releases/v7.0.0/insert-snippet.png)
 
@@ -129,7 +142,8 @@ To prepopulate a field, you can use the following special placeholders in the `d
 
 - Click on insert.
 
-The following steps generate the following outcome in the content (based on the above snippet example):
+The following steps generate the following outcome in the content (based on the above snippet
+example):
 
 ```markdown
 {{< highlight typescript "linenos=table,noclasses=false" >}}
@@ -139,7 +153,9 @@ The following steps generate the following outcome in the content (based on the 
 
 ## Media snippets
 
-Media snippets are intended to be used when you want to insert a media file in your content. Media snippets are defined in the `frontMatter.content.snippets` setting, with the `isMediaSnippet` property set to `true`.
+Media snippets are intended to be used when you want to insert a media file in your content. Media
+snippets are defined in the `frontMatter.content.snippets` setting, with the `isMediaSnippet`
+property set to `true`.
 
 ```json
 "frontMatter.content.snippets": {
@@ -151,9 +167,12 @@ Media snippets are intended to be used when you want to insert a media file in y
 }
 ```
 
-> **Info**: The media snippets provide you with a couple of media placeholders that you can use in your snippet body.
+> **Info**: The media snippets provide you with a couple of media placeholders that you can use in
+> your snippet body.
 
-Media snippets will appear on your snippets dashboard, but can only be edited or deleted. You cannot insert media snippets into your content like you can with content snippets. Instead, you will find them on the media cards.
+Media snippets will appear on your snippets dashboard, but can only be edited or deleted. You cannot
+insert media snippets into your content like you can with content snippets. Instead, you will find
+them on the media cards.
 
 ![Media snippet](/releases/v7.3.0/media-snippets.png)
 
@@ -169,12 +188,15 @@ The available placeholders for your media snippets are the following:
 - `filename`: Name of the file.
 - `title`: Title of the file.
 
-> **Info**: All placeholders are optional, so you can leave out the placeholders you do not want to use from your snippet.
+> **Info**: All placeholders are optional, so you can leave out the placeholders you do not want to
+> use from your snippet.
 
 ### Fields
 
-Like the content snippets, you can also define fields for your media snippets. These fields will be shown when you insert the snippet into your content.
+Like the content snippets, you can also define fields for your media snippets. These fields will be
+shown when you insert the snippet into your content.
 
+<!-- markdownlint-disable MD013 -->
 ```json
 "frontMatter.content.snippets": {
   "Image snippet": {
@@ -192,3 +214,4 @@ Like the content snippets, you can also define fields for your media snippets. T
   }
 }
 ```
+<!-- markdownlint-enable MD013 -->

--- a/content/docs/snippets/index.md
+++ b/content/docs/snippets/index.md
@@ -17,7 +17,7 @@ project/website.
 
 All snippets can be found on the snippets dashboard.
 
-![Snippet dashboard](/releases/v7.0.0/snippet-dashboard.png)
+![Snippet dashboard][01]
 
 ## Create a snippet
 
@@ -78,7 +78,7 @@ Each placeholder defined, will have a corresponding field definition. If no fiel
 defined for a placeholder, it will be shown as a input field when inserting the snippet.
 
 The field definition is the same as the one we use for our content types (more information at
-[defining your own content type](/docs/content-creation/content-types#define-your-own-type)).
+[defining your own content type][02]).
 
 At this moment, we only support the following field types:
 
@@ -88,8 +88,7 @@ At this moment, we only support the following field types:
 To prepopulate a field, you can use the following special placeholders in the `default` property of
 your field:
 
-- Standard placeholders are available like `{{year}}`, `{{month}}`, ... (see
-  [Placeholders](/docs/content-creation/placeholders))
+- Standard placeholders are available like `{{year}}`, `{{month}}`, ... (see [Placeholders][03])
 - `FM_SELECTED_TEXT`: This placeholder can be used to insert the selected text from the editor.
 
 **Example:**
@@ -133,12 +132,12 @@ your field:
 - Click on the **Insert snippet** button (or use the **Front Matter: Insert snippet into your
   content** command);
 
-![Insert a snippet](/releases/v7.0.0/insert-snippet.png)
+![Insert a snippet][04]
 
 - Select the snippet you want to use;
 - Fill in the fields;
 
-![Fill in the snippet form](/releases/v7.0.0/insert-snippet-form.png)
+![Fill in the snippet form][05]
 
 - Click on insert.
 
@@ -174,7 +173,7 @@ Media snippets will appear on your snippets dashboard, but can only be edited or
 insert media snippets into your content like you can with content snippets. Instead, you will find
 them on the media cards.
 
-![Media snippet](/releases/v7.3.0/media-snippets.png)
+![Media snippet][06]
 
 ### Placeholders
 
@@ -215,3 +214,11 @@ shown when you insert the snippet into your content.
 }
 ```
 <!-- markdownlint-enable MD013 -->
+
+<!-- Link References -->
+[01]: /releases/v7.0.0/snippet-dashboard.png
+[02]: /docs/content-creation/content-types#define-your-own-type
+[03]: /docs/content-creation/placeholders
+[04]: /releases/v7.0.0/insert-snippet.png
+[05]: /releases/v7.0.0/insert-snippet-form.png
+[06]: /releases/v7.3.0/media-snippets.png

--- a/content/docs/static-site-generators/hugo-configuration.md
+++ b/content/docs/static-site-generators/hugo-configuration.md
@@ -13,18 +13,17 @@ weight: 600.1
 
 Start by opening your Hugo project in Visual Studio Code.
 
-> **Info**: For this article, we made use of the
-> [Hugo Example site](https://github.com/gohugoio/hugoBasicExample) in combination with the
+> **Info**: For this article, we made use of the [Hugo Example site][01] in combination with the
 > _beautifulhugo_ theme.
 
-![Opening your Hugo project in VS Code](/hugo-configuration/hugo-configuration1.png)
+![Opening your Hugo project in VS Code][02]
 
 ## Installing Front Matter
 
 Open the extensions panel in Visual Studio Code and search for Front Matter. Once you find it, click
 on the install button.
 
-![Installing Front Matter extension](/hugo-configuration/hugo-configuration2.png)
+![Installing Front Matter extension][03]
 
 The welcome dashboard appears if this is the first time you use Front Matter.
 
@@ -38,7 +37,7 @@ the `Front Matter: Open dashboard` command. The steps to perform go as follows:
 
 The welcome dashboard looks as follows:
 
-![Welcome dashboard](/hugo-configuration/hugo-configuration3.png)
+![Welcome dashboard][04]
 
 ## Configuration of Front Matter
 
@@ -47,14 +46,14 @@ The welcome dashboard looks as follows:
 On the welcome screen, click on the `Initialize project` action. This action creates the
 `.frontmatter` folder and `frontmatter.json` file in the current project.
 
-![Project intialization](/hugo-configuration/hugo-configuration4.png)
+![Project intialization][05]
 
 ### Framework or static-site generator
 
 Next is to let Front Matter know which framework or static-site generator you use. In this case, we
 will pick **Hugo**.
 
-![Selecting your framework or static-site generator](/hugo-configuration/hugo-configuration5.png)
+![Selecting your framework or static-site generator][06]
 
 ### Content folders
 
@@ -65,17 +64,17 @@ To configure this, you need to open the `explorer panel` and perform the followi
 - Right-click on the folder you want to add;
 - From the folder menu, click on `Front Matter: Register folder`;
 
-![Register content folder](/hugo-configuration/hugo-configuration6.png)
+![Register content folder][07]
 
 - Front Matter will ask you what name you want to give this folder. By default, it will take the
   same name as the added folder.
 
-![Specify a name for the content folder](/hugo-configuration/hugo-configuration7.png)
+![Specify a name for the content folder][08]
 
 - Once you complete this step, Front Matter's configuration is completed and opens the content
   dashboard.
 
-![Content dashboard](/hugo-configuration/hugo-configuration8.png)
+![Content dashboard][09]
 
 > **Info**: You can perform these steps for one folder or many. For instance, if you have multiple
 > content types like blogs, posts, articles, news, etc. You can register each folder the same way.
@@ -85,9 +84,22 @@ To configure this, you need to open the `explorer panel` and perform the followi
 Now that Front Matter is configured, you can start creating content or managing your content via the
 Front Matter panel.
 
-![Front Matter panel for content management](/hugo-configuration/hugo-configuration9.png)
+![Front Matter panel for content management][10]
 
 ## Extra configuration steps
 
 If you want, you can further configure Front Matter to your preferences. Check more in our
-documentation what you can do: [documentation](/docs)
+documentation what you can do: [documentation][11]
+
+<!-- Link References -->
+[01]: https://github.com/gohugoio/hugoBasicExample
+[02]: /hugo-configuration/hugo-configuration1.png
+[03]: /hugo-configuration/hugo-configuration2.png
+[04]: /hugo-configuration/hugo-configuration3.png
+[05]: /hugo-configuration/hugo-configuration4.png
+[06]: /hugo-configuration/hugo-configuration5.png
+[07]: /hugo-configuration/hugo-configuration6.png
+[08]: /hugo-configuration/hugo-configuration7.png
+[09]: /hugo-configuration/hugo-configuration8.png
+[10]: /hugo-configuration/hugo-configuration9.png
+[11]: /docs

--- a/content/docs/static-site-generators/hugo-configuration.md
+++ b/content/docs/static-site-generators/hugo-configuration.md
@@ -11,21 +11,25 @@ weight: 600.1
 
 ## Setting up Front Matter for your Hugo site
 
-Start by opening your Hugo project in Visual Studio Code. 
+Start by opening your Hugo project in Visual Studio Code.
 
-> **Info**: For this article, we made use of the [Hugo Example site](https://github.com/gohugoio/hugoBasicExample) in combination with the *beautifulhugo* theme.
+> **Info**: For this article, we made use of the
+> [Hugo Example site](https://github.com/gohugoio/hugoBasicExample) in combination with the
+> _beautifulhugo_ theme.
 
 ![Opening your Hugo project in VS Code](/hugo-configuration/hugo-configuration1.png)
 
 ## Installing Front Matter
 
-Open the extensions panel in Visual Studio Code and search for Front Matter. Once you find it, click on the install button.
+Open the extensions panel in Visual Studio Code and search for Front Matter. Once you find it, click
+on the install button.
 
 ![Installing Front Matter extension](/hugo-configuration/hugo-configuration2.png)
 
-The welcome dashboard appears if this is the first time you use Front Matter. 
+The welcome dashboard appears if this is the first time you use Front Matter.
 
-If you have already installed or used Front Matter before, you can open the dashboard by executing the `Front Matter: Open dashboard` command. The steps to perform go as follows:
+If you have already installed or used Front Matter before, you can open the dashboard by executing
+the `Front Matter: Open dashboard` command. The steps to perform go as follows:
 
 - Open the command prompt:
   - Windows `⇧+ctrl+P`
@@ -40,19 +44,21 @@ The welcome dashboard looks as follows:
 
 ### Project initialization
 
-On the welcome screen, click on the `Initialize project` action. This action creates the `.frontmatter` folder and `frontmatter.json` file in the current project.
+On the welcome screen, click on the `Initialize project` action. This action creates the
+`.frontmatter` folder and `frontmatter.json` file in the current project.
 
 ![Project intialization](/hugo-configuration/hugo-configuration4.png)
 
 ### Framework or static-site generator
 
-Next is to let Front Matter know which framework or static-site generator you use. In this case, we will pick **Hugo**.
+Next is to let Front Matter know which framework or static-site generator you use. In this case, we
+will pick **Hugo**.
 
 ![Selecting your framework or static-site generator](/hugo-configuration/hugo-configuration5.png)
 
 ### Content folders
 
-Content folders are the locations where Front Matter needs to know where to create your `markdown` pages. 
+Content folders are the locations where Front Matter needs to know where to create your `markdown` pages.
 
 To configure this, you need to open the `explorer panel` and perform the following steps:
 
@@ -61,22 +67,27 @@ To configure this, you need to open the `explorer panel` and perform the followi
 
 ![Register content folder](/hugo-configuration/hugo-configuration6.png)
 
-- Front Matter will ask you what name you want to give this folder. By default, it will take the same name as the added folder.
+- Front Matter will ask you what name you want to give this folder. By default, it will take the
+  same name as the added folder.
 
 ![Specify a name for the content folder](/hugo-configuration/hugo-configuration7.png)
 
-- Once you complete this step, Front Matter's configuration is completed and opens the content dashboard.
+- Once you complete this step, Front Matter's configuration is completed and opens the content
+  dashboard.
 
 ![Content dashboard](/hugo-configuration/hugo-configuration8.png)
 
-> **Info**: You can perform these steps for one folder or many. For instance, if you have multiple content types like blogs, posts, articles, news, etc. You can register each folder the same way.
+> **Info**: You can perform these steps for one folder or many. For instance, if you have multiple
+> content types like blogs, posts, articles, news, etc. You can register each folder the same way.
 
 ## Using Front Matter
 
-Now that Front Matter is configured, you can start creating content or managing your content via the Front Matter panel.
+Now that Front Matter is configured, you can start creating content or managing your content via the
+Front Matter panel.
 
 ![Front Matter panel for content management](/hugo-configuration/hugo-configuration9.png)
 
 ## Extra configuration steps
 
-If you want, you can further configure Front Matter to your preferences. Check more in our documentation what you can do: [documentation](/docs)
+If you want, you can further configure Front Matter to your preferences. Check more in our
+documentation what you can do: [documentation](/docs)

--- a/content/docs/static-site-generators/index.md
+++ b/content/docs/static-site-generators/index.md
@@ -35,35 +35,39 @@ just add these to the `frontMatter.content.supportedFileTypes` setting.
 ### Hugo
 
 Check out our Hugo configuration documentation to get you started using Front Matter:
-[Front Matter configuration with Hugo](/docs/ssg-and-frameworks/hugo-configuration).
+[Front Matter configuration with Hugo][01].
 
 ### Eleventy
 
 _Are you up for the challenge of writing this part of the documentation?_
 
-[Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
+[Update the docs][02]
 
 ### Gatsby
 
 _Are you up for the challenge of writing this part of the documentation?_
 
-[Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
+[Update the docs][02]
 
 ### Next.js
 
 _Are you up for the challenge of writing this part of the documentation?_
 
-[Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
+[Update the docs][02]
 
 ### SvelteKit
 
 _Are you up for the challenge of writing this part of the documentation?_
 
-[Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
+[Update the docs][02]
 
 <!-- markdownlint-disable-next-line MD026 -->
 ### ...
 
 _Are you using one which hasn't been referenced yet? Feel free to add it here._
 
-[Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
+[Update the docs][02]
+
+<!-- Link Reference -->
+[01]: /docs/ssg-and-frameworks/hugo-configuration
+[02]: https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md

--- a/content/docs/static-site-generators/index.md
+++ b/content/docs/static-site-generators/index.md
@@ -11,15 +11,20 @@ weight: 600
 
 ## Overview
 
-Front Matter's goal is not to be opinionated on which static site generator or framework you are using. We want to support all of them out there, but they can have their requirements, configurations, ...
+Front Matter's goal is not to be opinionated on which static site generator or framework you are
+using. We want to support all of them out there, but they can have their requirements,
+configurations, ...
 
 In this section of the documentation, we will list them up and tell more about how you can get started.
 
 ## Support additional file types
 
-As there are many static site generators out there, we probably do not support all the file types by default. However, you do not have to worry, if there is a file type you want to support, you can easily add it to the `frontMatter.content.supportedFileTypes` setting.
+As there are many static site generators out there, we probably do not support all the file types by
+default. However, you do not have to worry, if there is a file type you want to support, you can
+easily add it to the `frontMatter.content.supportedFileTypes` setting.
 
-By default, Front Matter supports: `md`, `markdown`, and `mdx`. If you want to support other types, just add these to the `frontMatter.content.supportedFileTypes` setting.
+By default, Front Matter supports: `md`, `markdown`, and `mdx`. If you want to support other types,
+just add these to the `frontMatter.content.supportedFileTypes` setting.
 
 ```json
 {
@@ -29,34 +34,36 @@ By default, Front Matter supports: `md`, `markdown`, and `mdx`. If you want to s
 
 ### Hugo
 
-Check out our Hugo configuration documentation to get you started using Front Matter: [Front Matter configuration with Hugo](/docs/ssg-and-frameworks/hugo-configuration).
+Check out our Hugo configuration documentation to get you started using Front Matter:
+[Front Matter configuration with Hugo](/docs/ssg-and-frameworks/hugo-configuration).
 
 ### Eleventy
 
-*Are you up for the challenge of writing this part of the documentation?*
+_Are you up for the challenge of writing this part of the documentation?_
 
 [Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
 
 ### Gatsby
 
-*Are you up for the challenge of writing this part of the documentation?*
+_Are you up for the challenge of writing this part of the documentation?_
 
 [Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
 
 ### Next.js
 
-*Are you up for the challenge of writing this part of the documentation?*
+_Are you up for the challenge of writing this part of the documentation?_
 
 [Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
 
 ### SvelteKit
 
-*Are you up for the challenge of writing this part of the documentation?*
+_Are you up for the challenge of writing this part of the documentation?_
 
 [Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)
 
+<!-- markdownlint-disable-next-line MD026 -->
 ### ...
 
-*Are you using one which hasn't been referenced yet? Feel free to add it here.*
+_Are you using one which hasn't been referenced yet? Feel free to add it here._
 
 [Update the docs](https://github.com/FrontMatter/web-documentation-nextjs/edit/main/content/docs/ssg.md)

--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -11,53 +11,73 @@ weight: 1000
 
 ## Overview
 
-Unfortunately, sometimes you may encounter issues with the Front Matter extension. This can be due to the fact that there are misconfigurations, issues parsing your content, or bugs. We are constantly working to improve the extension and fix any issues you may encounter. In this section you can read what you can do to help you troubleshoot your Front Matter configuration.
+Unfortunately, sometimes you may encounter issues with the Front Matter extension. This can be due
+to the fact that there are misconfigurations, issues parsing your content, or bugs. We are
+constantly working to improve the extension and fix any issues you may encounter. In this section
+you can read what you can do to help you troubleshoot your Front Matter configuration.
 
 ## Content and front matter parsing
 
-One of the main issues you may encounter is that there is something wrong in your markdown its front matter. This can be due to a typo, a missing comma, or a missing colon, ...
+One of the main issues you may encounter is that there is something wrong in your markdown its front
+matter. This can be due to a typo, a missing comma, or a missing colon, ...
 
-The extension uses a YAML or TOML parser, depending on the type of front matter you are using. If the extension would spot an error during the content parsing, it will highlight this in the editor and on the problems tab.
+The extension uses a YAML or TOML parser, depending on the type of front matter you are using. If
+the extension would spot an error during the content parsing, it will highlight this in the editor
+and on the problems tab.
 
 ![Troubleshooting - Informing you of a parsing issue in the front matter of your article](/releases/v5.8.0/troubleshooting.png)
 
 ## Looking what is happening behind the scenes
 
-The extension logs information, warnings, and errors into the Visual Studio Code output tab. You can find the log stream by selecting the `vscode-front-matter` or `vscode-front-matter-beta` extension from the output dropdown.
+The extension logs information, warnings, and errors into the Visual Studio Code output tab. You can
+find the log stream by selecting the `vscode-front-matter` or `vscode-front-matter-beta` extension
+from the output dropdown.
 
 ![Troubleshooting - Show the output of what the extension has been performing](/releases/v5.8.0/troubleshooting-output.png)
 
 ## Inspecting configuration behavior
 
-With the [diagnostic logging](/docs/commands#diagnostic-logging) command, you can see your current configuration and related information in a virtual Markdown document.
+With the [diagnostic logging](/docs/commands#diagnostic-logging) command, you can see your current
+configuration and related information in a virtual Markdown document.
 
 The document has several sections:
 
-- **Folders** lists the entries defined in `frontMatter.content.pageFolders` by their title and the full path to each folder.
+- **Folders** lists the entries defined in `frontMatter.content.pageFolders` by their title and the
+  full path to each folder.
 - **Workspace folder** notes the full path to your project's workspace.
 - **Total files** notes the total file count for your workspace.
-- **Folders to search files** lists the count for discovered files by type in your content folders and includes the search glob used.
-- **Complete frontmatter.json config** shows the current configuration JSON. If you [split your configuration settings](/docs/settings#splitting-your-settings-in-multiple-files), it shows the fully composed configuration.
+- **Folders to search files** lists the count for discovered files by type in your content folders
+  and includes the search glob used.
+- **Complete frontmatter.json config** shows the current configuration JSON. If you
+  [split your configuration settings](/docs/settings#splitting-your-settings-in-multiple-files), it
+  shows the fully composed configuration.
 
 ## Feature migrations
 
-Sometimes it happens features get renamed or removed, under this section we will show you how to migrate your configuration to the new version.
+Sometimes it happens features get renamed or removed, under this section we will show you how to
+migrate your configuration to the new version.
 
 ### Publish and modified date migration
 
-In version 7, the `frontMatter.taxonomy.dateField` and `frontMatter.taxonomy.modifiedField` settings have been deprecated. These settings are now replaced by two new content type field properties:
+In version 7, the `frontMatter.taxonomy.dateField` and `frontMatter.taxonomy.modifiedField` settings
+have been deprecated. These settings are now replaced by two new content type field properties:
 
 - `isPublishDate`: defines the publish date
 - `isModifiedDate`: define the modified date
 
 Follow the next steps in order to migrate your settings to the new properties:
 
-**No custom content type**
+#### No custom content type
 
-When you use the default content type from Front Matter, you will already use the `isPublishDate` property. In case you were using the `frontMatter.taxonomy.modifiedField`, you will need to define your own content type and use the `isModifiedDate` property.
+When you use the default content type from Front Matter, you will already use the `isPublishDate`
+property. In case you were using the `frontMatter.taxonomy.modifiedField`, you will need to define
+your own content type and use the `isModifiedDate` property.
 
-Check the [change the default content type](/docs/content-creation/content-types#changing-the-default-content-type) section for more information.
+Check the
+[change the default content type](/docs/content-creation/content-types#changing-the-default-content-type)
+section for more information.
 
-**When using a custom content type**
+#### When using a custom content type
 
-When you already have a custom content type defined, you can set the `isPublishDate` and `isModifiedDate` properties for the `datetime` fields.
+When you already have a custom content type defined, you can set the `isPublishDate` and
+`isModifiedDate` properties for the `datetime` fields.

--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -25,7 +25,7 @@ The extension uses a YAML or TOML parser, depending on the type of front matter 
 the extension would spot an error during the content parsing, it will highlight this in the editor
 and on the problems tab.
 
-![Troubleshooting - Informing you of a parsing issue in the front matter of your article](/releases/v5.8.0/troubleshooting.png)
+![Troubleshooting - Informing you of a parsing issue in the front matter of your article][01]
 
 ## Looking what is happening behind the scenes
 
@@ -33,12 +33,12 @@ The extension logs information, warnings, and errors into the Visual Studio Code
 find the log stream by selecting the `vscode-front-matter` or `vscode-front-matter-beta` extension
 from the output dropdown.
 
-![Troubleshooting - Show the output of what the extension has been performing](/releases/v5.8.0/troubleshooting-output.png)
+![Troubleshooting - Show the output of what the extension has been performing][02]
 
 ## Inspecting configuration behavior
 
-With the [diagnostic logging](/docs/commands#diagnostic-logging) command, you can see your current
-configuration and related information in a virtual Markdown document.
+With the [diagnostic logging][03] command, you can see your current configuration and related
+information in a virtual Markdown document.
 
 The document has several sections:
 
@@ -49,7 +49,7 @@ The document has several sections:
 - **Folders to search files** lists the count for discovered files by type in your content folders
   and includes the search glob used.
 - **Complete frontmatter.json config** shows the current configuration JSON. If you
-  [split your configuration settings](/docs/settings#splitting-your-settings-in-multiple-files), it
+  [split your configuration settings][04], it
   shows the fully composed configuration.
 
 ## Feature migrations
@@ -73,11 +73,16 @@ When you use the default content type from Front Matter, you will already use th
 property. In case you were using the `frontMatter.taxonomy.modifiedField`, you will need to define
 your own content type and use the `isModifiedDate` property.
 
-Check the
-[change the default content type](/docs/content-creation/content-types#changing-the-default-content-type)
-section for more information.
+Check the [change the default content type][05] section for more information.
 
 #### When using a custom content type
 
 When you already have a custom content type defined, you can set the `isPublishDate` and
 `isModifiedDate` properties for the `datetime` fields.
+
+<!-- Link References -->
+[01]: /releases/v5.8.0/troubleshooting.png
+[02]: /releases/v5.8.0/troubleshooting-output.png
+[03]: /docs/commands#diagnostic-logging
+[04]: /docs/settings#splitting-your-settings-in-multiple-files
+[05]: /docs/content-creation/content-types#changing-the-default-content-type


### PR DESCRIPTION
This change introduces markdownlint to the project, defining a basic configuration to enforce consistent syntax. It steps through the process, first adding the configuration, then settings/recommendations, then addressing the initial violations, and finally replaces inline links with reference links for readability.

For more information, see each commit in this changeset.